### PR TITLE
Add static config files and Docker test infrastructure

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+[*.py]
+indent_size = 4
+
+[Makefile]
+indent_style = tab

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,3 @@
+disable=SC1090
+disable=SC1091
+shell=bash

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Toshimitsu Watanabe
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/test/Dockerfile.ubuntu
+++ b/test/Dockerfile.ubuntu
@@ -1,0 +1,16 @@
+FROM ubuntu:22.04
+
+RUN apt-get update && apt-get install -y \
+    sudo \
+    git \
+    curl \
+    zsh \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN useradd -m -s /bin/bash testuser && \
+    echo "testuser ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+
+WORKDIR /home/testuser/dotfiles
+COPY --chown=testuser:testuser . .
+
+USER testuser

--- a/test/test-install.sh
+++ b/test/test-install.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Integration test for install.sh
+set -euo pipefail
+
+DOTFILES_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+ERRORS=0
+
+echo "=== Syntax check ==="
+bash -n "$DOTFILES_DIR/install.sh" || { echo "FAIL: install.sh syntax error"; ERRORS=$((ERRORS + 1)); }
+
+echo "=== Running install.sh ==="
+bash "$DOTFILES_DIR/install.sh"
+
+echo "=== Verifying symlinks ==="
+EXPECTED_LINKS=(
+    "$HOME/.zshrc"
+    "$HOME/.bashrc"
+    "$HOME/.bash_profile"
+    "$HOME/.profile"
+    "$HOME/.vimrc"
+    "$HOME/.tmux.conf"
+)
+
+for link in "${EXPECTED_LINKS[@]}"; do
+    if [ -L "$link" ]; then
+        echo "  OK: $link"
+    else
+        echo "  FAIL: $link is not a symlink"
+        ERRORS=$((ERRORS + 1))
+    fi
+done
+
+echo "=== Directory symlinks ==="
+for dir_link in "$HOME/.shell-utils" "$HOME/oh-my-posh-theme"; do
+    if [ -L "$dir_link" ]; then
+        echo "  OK: $dir_link"
+    else
+        echo "  FAIL: $dir_link is not a symlink"
+        ERRORS=$((ERRORS + 1))
+    fi
+done
+
+echo ""
+if [ "$ERRORS" -eq 0 ]; then
+    echo "All tests passed!"
+else
+    echo "FAILED: $ERRORS error(s)"
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- Add Docker test infrastructure (`test/Dockerfile.ubuntu`, `test/test-install.sh`) for verifying install.sh
- Add MIT LICENSE (2024, Toshimitsu Watanabe)
- Add `.editorconfig` for consistent formatting (UTF-8, LF, 2-space indent for sh/json/yaml/md, 4-space for py)
- Add `.shellcheckrc` (disable SC1090/SC1091, shell=bash)

## Test plan
- [ ] `bash -n test/test-install.sh` passes syntax check
- [ ] `.editorconfig` rules match project conventions
- [ ] `shellcheck` respects `.shellcheckrc` directives

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>