### PR TITLE
Replace which with command -v and remove dead code

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -106,11 +106,9 @@ zstyle ":completion:*:git-checkout:*" sort false
 ########################
 # * cd ~hoge と入力すると /long/path/to/hogehoge ディレクトリに移動
 hash -d dev=~/dev
-hash -d win=/mnt/c/
 hash -d ghq=~/ghq
 hash -d zshrc=~/.zshrc
 hash -d dotfiles=~/dotfiles
-hash -d desktop=/mnt/c/Users/kz86n/Desktop/
 
 ########################
 # * cmd history setteing
@@ -174,28 +172,6 @@ bindkey '^[[B' history-substring-search-down
 #########
 # funcs
 #########
-# * open in windows
-if [[ $(uname -r) =~ microsoft ]]; then
-    local Chrome='/mnt/c/Program\ Files/Google/Chrome/Application/chrome.exe'
-    function open(){
-        if [ $# -eq 0 ]; then
-            echo "ERROR: get no input argument."
-            echo "Please specify file-paths, URLs, googling-words"
-            echo "open [file/path]"
-            return 1
-        fi
-        for arg; do
-            if [ -e "${arg}" ]; then
-                cmd.exe /c start $(readlink -f ${arg} | xargs wslpath -w)
-            elif [[ ${arg} =~ http ]]; then
-                echo "${arg}" | xargs -I{} bash -c "${Chrome} '{}'"
-            else
-                echo "${arg}" | sed 's/ /+/g' | xargs -I{} bash -c "${Chrome} 'https://www.google.com/search?q={}'"
-            fi
-        done
-    }
-fi
-
 # git prune
 git-branch-prune() {
     PROTECT_BRANCHES='master|develop|trunk|main|staging|production|release'
@@ -484,10 +460,6 @@ export KUBECONFIG=${KUBECONFIG}:$(echo ${kubeconfigs// /:})
   export SSH_AUTH_SOCK="$HOME/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock"
 
 [[ -f "$HOME/.docker/init-zsh.sh" ]] && source "$HOME/.docker/init-zsh.sh"
-# export PYENV_ROOT="$HOME/.pyenv"
-# command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"
-# eval "$(pyenv init -)"
-
 export PYENV_ROOT="$HOME/.pyenv"
 export PATH="$PYENV_ROOT/bin:$PATH"
 pyenv() {

--- a/.zshrc
+++ b/.zshrc
@@ -157,7 +157,7 @@ export FZF_CTRL_T_OPTS='--preview "bat  --color=always --style=header,grid --lin
 # workaround for puppeteer on m1 mac
 # See: https://github.com/puppeteer/puppeteer/issues/6622#issuecomment-788199984
 export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
-export PUPPETEER_EXECUTABLE_PATH=`which chromium`
+export PUPPETEER_EXECUTABLE_PATH=$(command -v chromium)
 #####################
 # COLORING          #
 #####################

--- a/install.sh
+++ b/install.sh
@@ -18,7 +18,7 @@ installApp() {
   echo "----------------------------------------------"
   echo "install ${app}"
   echo "----------------------------------------------"
-  which "$app" || ${manager} install -y "$app"
+  command -v "$app" || ${manager} install -y "$app"
 }
 
 installApps() {
@@ -135,11 +135,11 @@ setup_symlinks() {
 }
 
 install_fzf() {
-  if ! which fzf > /dev/null 2>&1; then
+  if ! command -v fzf > /dev/null 2>&1; then
     echo "----------------------------------------------"
     echo "install fzf"
     echo "----------------------------------------------"
-    if which brew > /dev/null 2>&1; then
+    if command -v brew > /dev/null 2>&1; then
       brew install fzf
     else
       git clone --depth 1 https://github.com/junegunn/fzf.git ~/.fzf
@@ -149,11 +149,11 @@ install_fzf() {
 }
 
 install_ghq() {
-  if ! which ghq > /dev/null 2>&1; then
+  if ! command -v ghq > /dev/null 2>&1; then
     echo "----------------------------------------------"
     echo "install ghq"
     echo "----------------------------------------------"
-    if which brew > /dev/null 2>&1; then
+    if command -v brew > /dev/null 2>&1; then
       brew install ghq
     else
       GO_BIN_DIR=~/go/bin
@@ -172,18 +172,18 @@ install_ghq() {
 }
 
 install_gh_cli() {
-  if ! which gh > /dev/null 2>&1; then
+  if ! command -v gh > /dev/null 2>&1; then
     echo "----------------------------------------------"
     echo "install github cli"
     echo "----------------------------------------------"
-    if which apt-get > /dev/null 2>&1; then
+    if command -v apt-get > /dev/null 2>&1; then
       apt-get install -y software-properties-common
       curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
       sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
       echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
       apt-get update
       apt-get install -y gh
-    elif which dnf > /dev/null 2>&1; then
+    elif command -v dnf > /dev/null 2>&1; then
       dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
       dnf install -y gh
     fi
@@ -200,7 +200,7 @@ setup_macos() {
   echo "=========================================="
 
   # Install Homebrew if not present
-  if ! which brew > /dev/null 2>&1; then
+  if ! command -v brew > /dev/null 2>&1; then
     echo "----------------------------------------------"
     echo "Installing Homebrew..."
     echo "----------------------------------------------"
@@ -239,19 +239,19 @@ setup_linux() {
     echo "Before installing brew,"
     echo "Install library to install brew requirements"
     echo "----------------------------------------------"
-    which brew || sudo apt-get install -y build-essential curl file git || sudo yum groupinstall -y 'Development Tools'
+    command -v brew || sudo apt-get install -y build-essential curl file git || sudo yum groupinstall -y 'Development Tools'
     sudo yum install -y curl file git 2>/dev/null
     sudo yum install -y libxcrypt-compat 2>/dev/null
     echo "----------------------------------------------"
     echo "Now, start installing brew"
     echo "----------------------------------------------"
-    which brew || /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+    command -v brew || /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
   fi
 
-  TEST_BREW=$(which brew 2>/dev/null)
-  TEST_APT=$(which apt-get 2>/dev/null)
-  TEST_DNF=$(which dnf 2>/dev/null)
-  TEST_YUM=$(which yum 2>/dev/null)
+  TEST_BREW=$(command -v brew 2>/dev/null)
+  TEST_APT=$(command -v apt-get 2>/dev/null)
+  TEST_DNF=$(command -v dnf 2>/dev/null)
+  TEST_YUM=$(command -v yum 2>/dev/null)
 
   if [ "$TEST_BREW" ] && [ "$WHO" != "root" ]; then
     echo "----------------------------------------------"


### PR DESCRIPTION
## Summary
- Replace all 16 `which` occurrences with `command -v` in `install.sh` and `.zshrc` for POSIX compliance
- Fix backtick subshell to `$()` form in `.zshrc` (PUPPETEER_EXECUTABLE_PATH)
- Remove dead code from `.zshrc`:
  - Commented-out pyenv initialization (3 lines)
  - WSL-specific hash bookmarks (`~win`, `~desktop`)
  - WSL-specific `open()` function (20 lines)

## Test plan
- [ ] `grep -rn '\bwhich\b' install.sh .zshrc` returns 0 results
- [ ] `bash -n install.sh` passes syntax check
- [ ] `source ~/.zshrc` loads without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>