### PR TITLE
Add install.sh robustness and uninstall.sh

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -106,11 +106,9 @@ zstyle ":completion:*:git-checkout:*" sort false
 ########################
 # * cd ~hoge と入力すると /long/path/to/hogehoge ディレクトリに移動
 hash -d dev=~/dev
-hash -d win=/mnt/c/
 hash -d ghq=~/ghq
 hash -d zshrc=~/.zshrc
 hash -d dotfiles=~/dotfiles
-hash -d desktop=/mnt/c/Users/kz86n/Desktop/
 
 ########################
 # * cmd history setteing
@@ -174,28 +172,6 @@ bindkey '^[[B' history-substring-search-down
 #########
 # funcs
 #########
-# * open in windows
-if [[ $(uname -r) =~ microsoft ]]; then
-    local Chrome='/mnt/c/Program\ Files/Google/Chrome/Application/chrome.exe'
-    function open(){
-        if [ $# -eq 0 ]; then
-            echo "ERROR: get no input argument."
-            echo "Please specify file-paths, URLs, googling-words"
-            echo "open [file/path]"
-            return 1
-        fi
-        for arg; do
-            if [ -e "${arg}" ]; then
-                cmd.exe /c start $(readlink -f ${arg} | xargs wslpath -w)
-            elif [[ ${arg} =~ http ]]; then
-                echo "${arg}" | xargs -I{} bash -c "${Chrome} '{}'"
-            else
-                echo "${arg}" | sed 's/ /+/g' | xargs -I{} bash -c "${Chrome} 'https://www.google.com/search?q={}'"
-            fi
-        done
-    }
-fi
-
 # git prune
 git-branch-prune() {
     PROTECT_BRANCHES='master|develop|trunk|main|staging|production|release'
@@ -484,10 +460,6 @@ export KUBECONFIG=${KUBECONFIG}:$(echo ${kubeconfigs// /:})
   export SSH_AUTH_SOCK="$HOME/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock"
 
 [[ -f "$HOME/.docker/init-zsh.sh" ]] && source "$HOME/.docker/init-zsh.sh"
-# export PYENV_ROOT="$HOME/.pyenv"
-# command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"
-# eval "$(pyenv init -)"
-
 export PYENV_ROOT="$HOME/.pyenv"
 export PATH="$PYENV_ROOT/bin:$PATH"
 pyenv() {

--- a/.zshrc
+++ b/.zshrc
@@ -157,7 +157,7 @@ export FZF_CTRL_T_OPTS='--preview "bat  --color=always --style=header,grid --lin
 # workaround for puppeteer on m1 mac
 # See: https://github.com/puppeteer/puppeteer/issues/6622#issuecomment-788199984
 export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
-export PUPPETEER_EXECUTABLE_PATH=`which chromium`
+export PUPPETEER_EXECUTABLE_PATH=$(command -v chromium)
 #####################
 # COLORING          #
 #####################

--- a/install.sh
+++ b/install.sh
@@ -18,7 +18,7 @@ installApp() {
   echo "----------------------------------------------"
   echo "install ${app}"
   echo "----------------------------------------------"
-  which "$app" || ${manager} install -y "$app"
+  command -v "$app" || ${manager} install -y "$app"
 }
 
 installApps() {
@@ -135,11 +135,11 @@ setup_symlinks() {
 }
 
 install_fzf() {
-  if ! which fzf > /dev/null 2>&1; then
+  if ! command -v fzf > /dev/null 2>&1; then
     echo "----------------------------------------------"
     echo "install fzf"
     echo "----------------------------------------------"
-    if which brew > /dev/null 2>&1; then
+    if command -v brew > /dev/null 2>&1; then
       brew install fzf
     else
       git clone --depth 1 https://github.com/junegunn/fzf.git ~/.fzf
@@ -149,11 +149,11 @@ install_fzf() {
 }
 
 install_ghq() {
-  if ! which ghq > /dev/null 2>&1; then
+  if ! command -v ghq > /dev/null 2>&1; then
     echo "----------------------------------------------"
     echo "install ghq"
     echo "----------------------------------------------"
-    if which brew > /dev/null 2>&1; then
+    if command -v brew > /dev/null 2>&1; then
       brew install ghq
     else
       GO_BIN_DIR=~/go/bin
@@ -172,18 +172,18 @@ install_ghq() {
 }
 
 install_gh_cli() {
-  if ! which gh > /dev/null 2>&1; then
+  if ! command -v gh > /dev/null 2>&1; then
     echo "----------------------------------------------"
     echo "install github cli"
     echo "----------------------------------------------"
-    if which apt-get > /dev/null 2>&1; then
+    if command -v apt-get > /dev/null 2>&1; then
       apt-get install -y software-properties-common
       curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
       sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
       echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
       apt-get update
       apt-get install -y gh
-    elif which dnf > /dev/null 2>&1; then
+    elif command -v dnf > /dev/null 2>&1; then
       dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
       dnf install -y gh
     fi
@@ -200,7 +200,7 @@ setup_macos() {
   echo "=========================================="
 
   # Install Homebrew if not present
-  if ! which brew > /dev/null 2>&1; then
+  if ! command -v brew > /dev/null 2>&1; then
     echo "----------------------------------------------"
     echo "Installing Homebrew..."
     echo "----------------------------------------------"
@@ -239,19 +239,19 @@ setup_linux() {
     echo "Before installing brew,"
     echo "Install library to install brew requirements"
     echo "----------------------------------------------"
-    which brew || sudo apt-get install -y build-essential curl file git || sudo yum groupinstall -y 'Development Tools'
+    command -v brew || sudo apt-get install -y build-essential curl file git || sudo yum groupinstall -y 'Development Tools'
     sudo yum install -y curl file git 2>/dev/null
     sudo yum install -y libxcrypt-compat 2>/dev/null
     echo "----------------------------------------------"
     echo "Now, start installing brew"
     echo "----------------------------------------------"
-    which brew || /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+    command -v brew || /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
   fi
 
-  TEST_BREW=$(which brew 2>/dev/null)
-  TEST_APT=$(which apt-get 2>/dev/null)
-  TEST_DNF=$(which dnf 2>/dev/null)
-  TEST_YUM=$(which yum 2>/dev/null)
+  TEST_BREW=$(command -v brew 2>/dev/null)
+  TEST_APT=$(command -v apt-get 2>/dev/null)
+  TEST_DNF=$(command -v dnf 2>/dev/null)
+  TEST_YUM=$(command -v yum 2>/dev/null)
 
   if [ "$TEST_BREW" ] && [ "$WHO" != "root" ]; then
     echo "----------------------------------------------"

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,20 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+log_info()  { echo "[INFO]  $*"; }
+log_warn()  { echo "[WARN]  $*" >&2; }
+log_error() { echo "[ERROR] $*" >&2; }
+
+backup_if_real_file() {
+  local target="$1"
+  if [ -e "$target" ] && [ ! -L "$target" ]; then
+    local backup_dir="$HOME/.dotfiles-backup/$(date +%Y%m%d_%H%M%S)"
+    mkdir -p "$backup_dir"
+    mv "$target" "$backup_dir/$(basename "$target")"
+    log_info "Backed up $(basename "$target") to $backup_dir/"
+  fi
+}
+
 DOTFILES_DIR="$(cd "$(dirname "$0")" && pwd)"
 WHO=$(whoami)
 
@@ -15,10 +31,14 @@ installApp() {
   local manager=$1
   local app=$2
 
-  echo "----------------------------------------------"
-  echo "install ${app}"
-  echo "----------------------------------------------"
-  command -v "$app" || ${manager} install -y "$app"
+  log_info "----------------------------------------------"
+  log_info "install ${app}"
+  log_info "----------------------------------------------"
+  if command -v "$app" > /dev/null 2>&1; then
+    log_info "$app is already installed"
+  else
+    ${manager} install -y "$app"
+  fi
 }
 
 installApps() {
@@ -58,9 +78,9 @@ installAppsNeedsBrew() {
   )
 
   for app in "${apps[@]}"; do
-    echo "----------------------------------------------"
-    echo "install ${app}"
-    echo "----------------------------------------------"
+    log_info "----------------------------------------------"
+    log_info "install ${app}"
+    log_info "----------------------------------------------"
     installApp brew "$app"
   done
 }
@@ -74,12 +94,13 @@ setup_symlinks() {
     .huskyrc .npmrc
   )
 
-  echo "----------------------------------------------"
-  echo "Setting up symlinks..."
-  echo "----------------------------------------------"
+  log_info "----------------------------------------------"
+  log_info "Setting up symlinks..."
+  log_info "----------------------------------------------"
 
   for file in "${files[@]}"; do
     if [ -f "$dotfiles_dir/$file" ]; then
+      backup_if_real_file "$HOME/$file"
       ln -fs "$dotfiles_dir/$file" "$HOME/$file"
       echo "  linked: $file"
     fi
@@ -95,6 +116,7 @@ setup_symlinks() {
   for file in "${config_files[@]}"; do
     if [ -f "$dotfiles_dir/$file" ]; then
       mkdir -p "$HOME/$(dirname "$file")"
+      backup_if_real_file "$HOME/$file"
       ln -fs "$dotfiles_dir/$file" "$HOME/$file"
       echo "  linked: $file"
     fi
@@ -118,6 +140,7 @@ setup_symlinks() {
   for file in "${claude_files[@]}"; do
     if [ -f "$dotfiles_dir/claude/$file" ]; then
       mkdir -p "$HOME/.claude/$(dirname "$file")"
+      backup_if_real_file "$HOME/.claude/$file"
       ln -fs "$dotfiles_dir/claude/$file" "$HOME/.claude/$file"
       echo "  linked: .claude/$file"
     fi
@@ -125,20 +148,35 @@ setup_symlinks() {
 
   # Directory symlinks: use -n to avoid following existing symlinks into the target
   # and rm -rf guard for the case where a real (non-symlink) directory exists
-  [ -d "$HOME/.shell-utils" ] && [ ! -L "$HOME/.shell-utils" ] && rm -rf "$HOME/.shell-utils"
+  if [ -d "$HOME/.shell-utils" ] && [ ! -L "$HOME/.shell-utils" ]; then rm -rf "$HOME/.shell-utils"; fi
   ln -fsn "$dotfiles_dir/.shell-utils" "$HOME/.shell-utils"
   echo "  linked: .shell-utils/"
 
-  [ -d "$HOME/oh-my-posh-theme" ] && [ ! -L "$HOME/oh-my-posh-theme" ] && rm -rf "$HOME/oh-my-posh-theme"
+  if [ -d "$HOME/oh-my-posh-theme" ] && [ ! -L "$HOME/oh-my-posh-theme" ]; then rm -rf "$HOME/oh-my-posh-theme"; fi
   ln -fsn "$dotfiles_dir/oh-my-posh-theme" "$HOME/oh-my-posh-theme"
   echo "  linked: oh-my-posh-theme/"
+
+  # Validate symlinks
+  log_info "Validating symlinks..."
+  local errors=0
+  for file in "${files[@]}"; do
+    if [ -f "$dotfiles_dir/$file" ] && [ ! -L "$HOME/$file" ]; then
+      log_error "Symlink validation failed: $HOME/$file"
+      errors=$((errors + 1))
+    fi
+  done
+  if [ "$errors" -eq 0 ]; then
+    log_info "All symlinks validated successfully"
+  else
+    log_error "$errors symlink(s) failed validation"
+  fi
 }
 
 install_fzf() {
   if ! command -v fzf > /dev/null 2>&1; then
-    echo "----------------------------------------------"
-    echo "install fzf"
-    echo "----------------------------------------------"
+    log_info "----------------------------------------------"
+    log_info "install fzf"
+    log_info "----------------------------------------------"
     if command -v brew > /dev/null 2>&1; then
       brew install fzf
     else
@@ -150,9 +188,9 @@ install_fzf() {
 
 install_ghq() {
   if ! command -v ghq > /dev/null 2>&1; then
-    echo "----------------------------------------------"
-    echo "install ghq"
-    echo "----------------------------------------------"
+    log_info "----------------------------------------------"
+    log_info "install ghq"
+    log_info "----------------------------------------------"
     if command -v brew > /dev/null 2>&1; then
       brew install ghq
     else
@@ -173,9 +211,9 @@ install_ghq() {
 
 install_gh_cli() {
   if ! command -v gh > /dev/null 2>&1; then
-    echo "----------------------------------------------"
-    echo "install github cli"
-    echo "----------------------------------------------"
+    log_info "----------------------------------------------"
+    log_info "install github cli"
+    log_info "----------------------------------------------"
     if command -v apt-get > /dev/null 2>&1; then
       apt-get install -y software-properties-common
       curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
@@ -195,22 +233,22 @@ install_gh_cli() {
 # ========================================
 
 setup_macos() {
-  echo "=========================================="
-  echo "Setting up macOS environment"
-  echo "=========================================="
+  log_info "=========================================="
+  log_info "Setting up macOS environment"
+  log_info "=========================================="
 
   # Install Homebrew if not present
   if ! command -v brew > /dev/null 2>&1; then
-    echo "----------------------------------------------"
-    echo "Installing Homebrew..."
-    echo "----------------------------------------------"
+    log_info "----------------------------------------------"
+    log_info "Installing Homebrew..."
+    log_info "----------------------------------------------"
     /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
     eval "$(/opt/homebrew/bin/brew shellenv)"
   fi
 
-  echo "----------------------------------------------"
-  echo "Running brew bundle..."
-  echo "----------------------------------------------"
+  log_info "----------------------------------------------"
+  log_info "Running brew bundle..."
+  log_info "----------------------------------------------"
   brew bundle --file="$DOTFILES_DIR/Brewfile"
 
   setup_symlinks "$DOTFILES_DIR"
@@ -221,31 +259,39 @@ setup_macos() {
 # ========================================
 
 setup_linux() {
-  echo "=========================================="
-  echo "Setting up Linux environment"
-  echo "=========================================="
+  log_info "=========================================="
+  log_info "Setting up Linux environment"
+  log_info "=========================================="
 
-  echo "----------------------------------------------"
-  echo "Run apt/yum update..."
-  echo "----------------------------------------------"
-  apt-get update -y || yum update -y || dnf update -y
+  log_info "----------------------------------------------"
+  log_info "Run apt/yum update..."
+  log_info "----------------------------------------------"
+  apt-get update -y || yum update -y || dnf update -y || true
   # Remove stale lock files if they exist (only needed when previous apt was interrupted)
-  [ -f /var/lib/dpkg/lock ] && sudo rm -f /var/lib/dpkg/lock
-  [ -f /var/lib/dpkg/lock-frontend ] && sudo rm -f /var/lib/dpkg/lock-frontend
-  [ -f /var/cache/apt/archives/lock ] && sudo rm -f /var/cache/apt/archives/lock
+  if [ -f /var/lib/dpkg/lock ]; then sudo rm -f /var/lib/dpkg/lock; fi
+  if [ -f /var/lib/dpkg/lock-frontend ]; then sudo rm -f /var/lib/dpkg/lock-frontend; fi
+  if [ -f /var/cache/apt/archives/lock ]; then sudo rm -f /var/cache/apt/archives/lock; fi
 
   if [ "$WHO" != "root" ]; then
-    echo "----------------------------------------------"
-    echo "Before installing brew,"
-    echo "Install library to install brew requirements"
-    echo "----------------------------------------------"
-    command -v brew || sudo apt-get install -y build-essential curl file git || sudo yum groupinstall -y 'Development Tools'
+    log_info "----------------------------------------------"
+    log_info "Before installing brew,"
+    log_info "Install library to install brew requirements"
+    log_info "----------------------------------------------"
+    if command -v brew > /dev/null 2>&1; then
+      log_info "brew is already installed"
+    else
+      sudo apt-get install -y build-essential curl file git || sudo yum groupinstall -y 'Development Tools'
+    fi
     sudo yum install -y curl file git 2>/dev/null
     sudo yum install -y libxcrypt-compat 2>/dev/null
-    echo "----------------------------------------------"
-    echo "Now, start installing brew"
-    echo "----------------------------------------------"
-    command -v brew || /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+    log_info "----------------------------------------------"
+    log_info "Now, start installing brew"
+    log_info "----------------------------------------------"
+    if command -v brew > /dev/null 2>&1; then
+      log_info "brew is already installed"
+    else
+      /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+    fi
   fi
 
   TEST_BREW=$(command -v brew 2>/dev/null)
@@ -254,19 +300,19 @@ setup_linux() {
   TEST_YUM=$(command -v yum 2>/dev/null)
 
   if [ "$TEST_BREW" ] && [ "$WHO" != "root" ]; then
-    echo "----------------------------------------------"
-    echo "Brew was installed!!"
-    echo "----------------------------------------------"
+    log_info "----------------------------------------------"
+    log_info "Brew was installed!!"
+    log_info "----------------------------------------------"
     eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
 
-    echo "----------------------------------------------"
-    echo "Run brew doctor..."
-    echo "----------------------------------------------"
+    log_info "----------------------------------------------"
+    log_info "Run brew doctor..."
+    log_info "----------------------------------------------"
     brew doctor
 
-    echo "----------------------------------------------"
-    echo "Run brew update..."
-    echo "----------------------------------------------"
+    log_info "----------------------------------------------"
+    log_info "Run brew update..."
+    log_info "----------------------------------------------"
     brew update
 
     installApps brew
@@ -310,6 +356,6 @@ case "$OS" in
 esac
 
 echo ""
-echo "=========================================="
-echo "Setup complete!"
-echo "=========================================="
+log_info "=========================================="
+log_info "Setup complete!"
+log_info "=========================================="

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Uninstall dotfiles: remove symlinks and optionally restore backups
+set -euo pipefail
+
+DOTFILES_DIR="$(cd "$(dirname "$0")" && pwd)"
+DRY_RUN=false
+
+log_info()  { echo "[INFO]  $*"; }
+log_warn()  { echo "[WARN]  $*" >&2; }
+
+usage() {
+  echo "Usage: $0 [--dry-run]"
+  echo "  --dry-run  Show what would be removed without making changes"
+  exit 0
+}
+
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=true ;;
+    --help|-h) usage ;;
+    *) echo "Unknown option: $arg"; usage ;;
+  esac
+done
+
+remove_symlink() {
+  local link="$1"
+  if [ -L "$link" ]; then
+    local target
+    target=$(readlink "$link")
+    # Only remove if it points to our dotfiles directory
+    case "$target" in
+      "$DOTFILES_DIR"*)
+        if $DRY_RUN; then
+          log_info "[DRY-RUN] Would remove: $link -> $target"
+        else
+          rm "$link"
+          log_info "Removed: $link"
+        fi
+        ;;
+      *)
+        log_warn "Skipping $link (points to $target, not our dotfiles)"
+        ;;
+    esac
+  fi
+}
+
+echo "Uninstalling dotfiles from $DOTFILES_DIR"
+if $DRY_RUN; then
+  echo "(Dry run mode - no changes will be made)"
+fi
+echo ""
+
+# File symlinks
+FILES=(
+  .zshrc .bashrc .bash_profile .bash_logout
+  .profile .zprofile .zshenv
+  .vimrc .tmux.conf .gitconfig
+  .huskyrc .npmrc
+)
+
+for file in "${FILES[@]}"; do
+  remove_symlink "$HOME/$file"
+done
+
+# .config/ files
+CONFIG_FILES=(
+  .config/git/ignore
+  .config/gh/config.yml
+  .config/ghostty/config
+)
+
+for file in "${CONFIG_FILES[@]}"; do
+  remove_symlink "$HOME/$file"
+done
+
+# Claude Code files
+CLAUDE_FILES=(
+  CLAUDE.md RTK.md settings.json statusline.sh
+  hooks/deny-check.sh hooks/notification.sh hooks/rtk-rewrite.sh hooks/validate-bash.sh
+  rules/testing/vitest.md rules/typescript/documentation.md rules/typescript/type-safety.md
+)
+
+for file in "${CLAUDE_FILES[@]}"; do
+  remove_symlink "$HOME/.claude/$file"
+done
+
+# Directory symlinks
+remove_symlink "$HOME/.shell-utils"
+remove_symlink "$HOME/oh-my-posh-theme"
+
+# Offer backup restore
+BACKUP_DIR="$HOME/.dotfiles-backup"
+if [ -d "$BACKUP_DIR" ]; then
+  echo ""
+  echo "Backups found in $BACKUP_DIR:"
+  ls -1 "$BACKUP_DIR"
+  echo ""
+  echo "To restore a backup, copy files from the backup directory to your home directory."
+  echo "Example: cp -r $BACKUP_DIR/<timestamp>/* ~/"
+fi
+
+echo ""
+echo "Uninstall complete!"


### PR DESCRIPTION
## Summary
- Change shebang to `#!/usr/bin/env bash` and add `set -euo pipefail`
- Add `log_info()`, `log_warn()`, `log_error()` logging helpers
- Add `backup_if_real_file()` to safely back up real files before symlinking (to `~/.dotfiles-backup/YYYYMMDD_HHMMSS/`)
- Convert `[ -f ] && cmd` patterns to `if` statements for `set -e` safety
- Add symlink validation after creation
- Create `uninstall.sh` with `readlink` safety check and `--dry-run` flag

## Test plan
- [ ] `bash -n install.sh && bash -n uninstall.sh` passes
- [ ] `bash install.sh` creates symlinks and logs output
- [ ] `bash uninstall.sh --dry-run` shows what would be removed
- [ ] Real files are backed up before symlink creation

Depends on: #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>