### PR TITLE
feat: add git-branch-open (gbo) and git-pr-open (gpo) aliases

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -224,6 +224,12 @@ alias gco='git checkout'
 alias gbd='cd-gitroot'
 alias gcd='cd $(ghq root)/$(ghq list | fzf)'
 alias gb-prune='git-branch-prune'
+alias git-branch-open='git open' # * need paulirish/git-open
+alias gbo='git-branch-open'
+if command -v gh &>/dev/null; then
+  alias git-pr-open='gh pr view --web' # open PR linked to current branch
+  alias gpo='git-pr-open'
+fi
 alias gcode='${OPEN_BY_MY_EDITOR} $(ghq root)/$(ghq list | fzf --preview "bat --color=always --style=header,grid --line-range :80 $(ghq root)/{}/README.*")'
 
 alias d='docker'


### PR DESCRIPTION
## Summary
- `git-branch-open` / `gbo`: wraps existing `git open` (paulirish/git-open) to open the current branch on GitHub
- `git-pr-open` / `gpo`: opens the PR linked to the current branch via `gh pr view --web` (guarded by `command -v gh`)

## Test plan
- [x] `zsh -n .zshrc` passes
- [x] Aliases resolve in interactive shell
- [x] `gh pr view --web` fails with a clear message when no PR exists