### PR TITLE
feat: make install.sh Codespaces-ready

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ bash install.sh
 
 Machine-specific shell config goes in `~/.zshrc.local` (sourced last, never tracked here).
 
+### Codespaces
+
+GitHub Settings → Codespaces → enable "Automatically install dotfiles" and select this repo.
+`install.sh` then runs automatically on codespace creation.
+Machine-specific config still goes in `~/.zshrc.local`.
+
 ## Key Tools
 
 - **Shell**: Zsh with [Zinit](https://github.com/zdharma-continuum/zinit) (lazy-loaded plugins)

--- a/install.sh
+++ b/install.sh
@@ -418,6 +418,7 @@ setup_macos() {
     echo "----------------------------------------------"
     echo "Installing Homebrew..."
     echo "----------------------------------------------"
+    export NONINTERACTIVE=1
     /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
     eval "$(/opt/homebrew/bin/brew shellenv)"
   fi
@@ -464,6 +465,7 @@ setup_linux() {
     echo "----------------------------------------------"
     echo "Now, start installing brew"
     echo "----------------------------------------------"
+    export NONINTERACTIVE=1
     command -v brew || /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
   fi
 


### PR DESCRIPTION
- export NONINTERACTIVE=1 before both Homebrew installer invocations (macOS/Linux paths) so brew never prompts under a non-TTY container even if a TTY exists
- add README Codespaces subsection (enable auto-install dotfiles in GitHub Settings)
- install.sh already tracked as executable (100755); no chmod needed

Closes #12

## Test plan
- [x] shellcheck -S warning install.sh: exit 0
- [x] docker build -t dotfiles-test-12 -f test/Dockerfile.ubuntu .: success
- [x] docker run --rm dotfiles-test-12 bash -c 'bash install.sh < /dev/null': exit 0, no hang; log shows "Running in non-interactive mode because \`\$NONINTERACTIVE\` is set." and "Installation successful!" for Homebrew
- [x] spot-checked ~/.zshrc and ~/.shell-utils symlinks resolve correctly after install