### PR TITLE
feat: add backup mechanism and uninstall.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 DOTFILES_DIR="$(cd "$(dirname "$0")" && pwd)"
 WHO=$(whoami)
+BACKUP_TIMESTAMP="$(date +%Y%m%d_%H%M%S)"
 
 # shellcheck source=symlink-manifest.sh
 source "$DOTFILES_DIR/symlink-manifest.sh"
@@ -68,6 +69,19 @@ installAppsNeedsBrew() {
   done
 }
 
+# Back up a real (non-symlink) file before it gets replaced by a symlink.
+# Moves it to ~/.dotfiles-backup/<run-timestamp>/<same relative path>.
+backup_if_real_file() {
+  local target=$1
+  [ -e "$target" ] && [ ! -L "$target" ] || return 0
+
+  local rel_path=${target#"$HOME/"}
+  local dest="$HOME/.dotfiles-backup/$BACKUP_TIMESTAMP/$rel_path"
+  mkdir -p "$(dirname "$dest")"
+  mv "$target" "$dest"
+  echo "  backed up: $rel_path"
+}
+
 setup_symlinks() {
   local dotfiles_dir="${1:-$DOTFILES_DIR}"
 
@@ -77,6 +91,7 @@ setup_symlinks() {
 
   for file in "${MANIFEST_FILES[@]}"; do
     if [ -f "$dotfiles_dir/$file" ]; then
+      backup_if_real_file "$HOME/$file"
       ln -fs "$dotfiles_dir/$file" "$HOME/$file"
       echo "  linked: $file"
     fi
@@ -86,6 +101,7 @@ setup_symlinks() {
   for file in "${MANIFEST_CONFIG_FILES[@]}"; do
     if [ -f "$dotfiles_dir/$file" ]; then
       mkdir -p "$HOME/$(dirname "$file")"
+      backup_if_real_file "$HOME/$file"
       ln -fs "$dotfiles_dir/$file" "$HOME/$file"
       echo "  linked: $file"
     fi
@@ -95,6 +111,7 @@ setup_symlinks() {
   for file in "${MANIFEST_CLAUDE_FILES[@]}"; do
     if [ -f "$dotfiles_dir/claude/$file" ]; then
       mkdir -p "$HOME/.claude/$(dirname "$file")"
+      backup_if_real_file "$HOME/.claude/$file"
       ln -fs "$dotfiles_dir/claude/$file" "$HOME/.claude/$file"
       echo "  linked: .claude/$file"
     fi
@@ -319,6 +336,7 @@ setup_vscode() {
   local user_dir="$HOME/Library/Application Support/Code/User"
   [ -d "$user_dir" ] || return 0
 
+  backup_if_real_file "$user_dir/keybindings.json"
   ln -fs "$DOTFILES_DIR/vscode/keybindings.json" "$user_dir/keybindings.json"
   echo "  linked: vscode keybindings.json"
 

--- a/install.sh
+++ b/install.sh
@@ -2,6 +2,9 @@
 DOTFILES_DIR="$(cd "$(dirname "$0")" && pwd)"
 WHO=$(whoami)
 
+# shellcheck source=symlink-manifest.sh
+source "$DOTFILES_DIR/symlink-manifest.sh"
+
 echo ""
 echo " ---------------"
 echo "| Hello ${WHO}! |"
@@ -67,18 +70,12 @@ installAppsNeedsBrew() {
 
 setup_symlinks() {
   local dotfiles_dir="${1:-$DOTFILES_DIR}"
-  local files=(
-    .zshrc .bashrc .bash_profile .bash_logout
-    .profile .zprofile .zshenv .shell-common
-    .vimrc .tmux.conf .gitconfig
-    .huskyrc .npmrc
-  )
 
   echo "----------------------------------------------"
   echo "Setting up symlinks..."
   echo "----------------------------------------------"
 
-  for file in "${files[@]}"; do
+  for file in "${MANIFEST_FILES[@]}"; do
     if [ -f "$dotfiles_dir/$file" ]; then
       ln -fs "$dotfiles_dir/$file" "$HOME/$file"
       echo "  linked: $file"
@@ -86,14 +83,7 @@ setup_symlinks() {
   done
 
   # .config/ subdirectory files (create parent dirs, then symlink individual files)
-  local config_files=(
-    .config/git/ignore
-    .config/gh/config.yml
-    .config/ghostty/config
-    .config/herdr/config.toml
-  )
-
-  for file in "${config_files[@]}"; do
+  for file in "${MANIFEST_CONFIG_FILES[@]}"; do
     if [ -f "$dotfiles_dir/$file" ]; then
       mkdir -p "$HOME/$(dirname "$file")"
       ln -fs "$dotfiles_dir/$file" "$HOME/$file"
@@ -102,32 +92,7 @@ setup_symlinks() {
   done
 
   # Claude Code global settings (claude/ → ~/.claude/)
-  local claude_files=(
-    CLAUDE.md
-    RTK.md
-    settings.json
-    statusline.sh
-    claude-powerline.json
-    hooks/deny-check.sh
-    hooks/notification.sh
-    hooks/rtk-rewrite.sh
-    hooks/validate-bash.sh
-    rules/testing/vitest.md
-    rules/typescript/documentation.md
-    rules/typescript/type-safety.md
-    rules/common/agents.md
-    rules/common/code-review.md
-    rules/common/coding-style.md
-    rules/common/development-workflow.md
-    rules/common/git-workflow.md
-    rules/common/hooks.md
-    rules/common/patterns.md
-    rules/common/performance.md
-    rules/common/security.md
-    rules/common/testing.md
-  )
-
-  for file in "${claude_files[@]}"; do
+  for file in "${MANIFEST_CLAUDE_FILES[@]}"; do
     if [ -f "$dotfiles_dir/claude/$file" ]; then
       mkdir -p "$HOME/.claude/$(dirname "$file")"
       ln -fs "$dotfiles_dir/claude/$file" "$HOME/.claude/$file"

--- a/symlink-manifest.sh
+++ b/symlink-manifest.sh
@@ -1,0 +1,46 @@
+# Shared manifest of dotfiles symlinked by install.sh and removed by uninstall.sh.
+# Sourced only — keep in sync with the actual repo layout.
+
+# shellcheck disable=SC2034  # consumed by install.sh / uninstall.sh via source
+MANIFEST_FILES=(
+  .zshrc .bashrc .bash_profile .bash_logout
+  .profile .zprofile .zshenv .shell-common
+  .vimrc .tmux.conf .gitconfig
+  .huskyrc .npmrc
+)
+
+# .config/ subdirectory files
+# shellcheck disable=SC2034  # consumed by install.sh / uninstall.sh via source
+MANIFEST_CONFIG_FILES=(
+  .config/git/ignore
+  .config/gh/config.yml
+  .config/ghostty/config
+  .config/herdr/config.toml
+)
+
+# Claude Code global settings (claude/ → ~/.claude/)
+# shellcheck disable=SC2034  # consumed by install.sh / uninstall.sh via source
+MANIFEST_CLAUDE_FILES=(
+  CLAUDE.md
+  RTK.md
+  settings.json
+  statusline.sh
+  claude-powerline.json
+  hooks/deny-check.sh
+  hooks/notification.sh
+  hooks/rtk-rewrite.sh
+  hooks/validate-bash.sh
+  rules/testing/vitest.md
+  rules/typescript/documentation.md
+  rules/typescript/type-safety.md
+  rules/common/agents.md
+  rules/common/code-review.md
+  rules/common/coding-style.md
+  rules/common/development-workflow.md
+  rules/common/git-workflow.md
+  rules/common/hooks.md
+  rules/common/patterns.md
+  rules/common/performance.md
+  rules/common/security.md
+  rules/common/testing.md
+)

--- a/test/test-install.sh
+++ b/test/test-install.sh
@@ -7,6 +7,11 @@ ERRORS=0
 
 echo "=== Syntax check ==="
 bash -n "$DOTFILES_DIR/install.sh" || { echo "FAIL: install.sh syntax error"; ERRORS=$((ERRORS + 1)); }
+bash -n "$DOTFILES_DIR/uninstall.sh" || { echo "FAIL: uninstall.sh syntax error"; ERRORS=$((ERRORS + 1)); }
+
+echo "=== Pre-creating a real .npmrc (to verify backup-before-symlink) ==="
+NPMRC_CONTENT="pre-existing npmrc content"
+echo "$NPMRC_CONTENT" > "$HOME/.npmrc"
 
 echo "=== Running install.sh ==="
 bash "$DOTFILES_DIR/install.sh"
@@ -39,6 +44,57 @@ for dir_link in "$HOME/.shell-utils" "$HOME/oh-my-posh-theme"; do
         ERRORS=$((ERRORS + 1))
     fi
 done
+
+echo "=== Verifying .npmrc was backed up before symlinking ==="
+if [ -L "$HOME/.npmrc" ]; then
+    echo "  OK: $HOME/.npmrc is now a symlink"
+else
+    echo "  FAIL: $HOME/.npmrc is not a symlink"
+    ERRORS=$((ERRORS + 1))
+fi
+
+BACKED_UP_NPMRC=""
+for candidate in "$HOME"/.dotfiles-backup/*/.npmrc; do
+    [ -f "$candidate" ] && BACKED_UP_NPMRC="$candidate"
+done
+
+if [ -n "$BACKED_UP_NPMRC" ] && grep -q "$NPMRC_CONTENT" "$BACKED_UP_NPMRC"; then
+    echo "  OK: backup found at $BACKED_UP_NPMRC"
+else
+    echo "  FAIL: no backup of the pre-existing .npmrc found under ~/.dotfiles-backup"
+    ERRORS=$((ERRORS + 1))
+fi
+
+echo "=== Creating a foreign symlink (must survive uninstall) ==="
+ln -sf /etc/hosts "$HOME/.foreign"
+
+echo "=== Running uninstall.sh ==="
+bash "$DOTFILES_DIR/uninstall.sh"
+
+echo "=== Verifying tracked symlinks were removed ==="
+for link in "$HOME/.zshrc" "$HOME/.vimrc"; do
+    if [ ! -e "$link" ] && [ ! -L "$link" ]; then
+        echo "  OK: $link removed"
+    else
+        echo "  FAIL: $link still present"
+        ERRORS=$((ERRORS + 1))
+    fi
+done
+
+if [ ! -e "$HOME/.shell-utils" ] && [ ! -L "$HOME/.shell-utils" ]; then
+    echo "  OK: $HOME/.shell-utils removed"
+else
+    echo "  FAIL: $HOME/.shell-utils still present"
+    ERRORS=$((ERRORS + 1))
+fi
+
+echo "=== Verifying the foreign symlink was left untouched ==="
+if [ -L "$HOME/.foreign" ]; then
+    echo "  OK: $HOME/.foreign still present"
+else
+    echo "  FAIL: $HOME/.foreign was removed"
+    ERRORS=$((ERRORS + 1))
+fi
 
 echo ""
 if [ "$ERRORS" -eq 0 ]; then

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# Remove dotfiles symlinks created by install.sh.
+# Only removes symlinks that resolve into this repo; real files and
+# foreign symlinks are left untouched. Backups (if any) are never restored
+# automatically; restore manually from ~/.dotfiles-backup.
+set -uo pipefail
+
+DOTFILES_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+DRY_RUN=0
+[ "${1:-}" = "--dry-run" ] && DRY_RUN=1
+
+# shellcheck source=symlink-manifest.sh
+source "$DOTFILES_DIR/symlink-manifest.sh"
+
+# Remove a symlink only if it points into this dotfiles repo.
+remove_if_dotfiles_symlink() {
+  local target=$1
+  [ -L "$target" ] || return 0
+
+  local link_target
+  link_target=$(readlink "$target")
+  case "$link_target" in
+    "$DOTFILES_DIR"/*) ;;
+    *) return 0 ;;
+  esac
+
+  if [ "$DRY_RUN" -eq 1 ]; then
+    echo "  would remove: $target"
+  else
+    rm -f "$target"
+    echo "  removed: $target"
+  fi
+}
+
+echo "----------------------------------------------"
+echo "Removing dotfiles symlinks..."
+echo "----------------------------------------------"
+
+for file in "${MANIFEST_FILES[@]}"; do
+  remove_if_dotfiles_symlink "$HOME/$file"
+done
+
+for file in "${MANIFEST_CONFIG_FILES[@]}"; do
+  remove_if_dotfiles_symlink "$HOME/$file"
+done
+
+for file in "${MANIFEST_CLAUDE_FILES[@]}"; do
+  remove_if_dotfiles_symlink "$HOME/.claude/$file"
+done
+
+remove_if_dotfiles_symlink "$HOME/.shell-utils"
+remove_if_dotfiles_symlink "$HOME/oh-my-posh-theme"
+
+if [ "$(uname -s)" = "Darwin" ]; then
+  remove_if_dotfiles_symlink "$HOME/Library/Application Support/Code/User/keybindings.json"
+fi
+
+if [ -d "$HOME/.dotfiles-backup" ]; then
+  latest_backup=""
+  for dir in "$HOME/.dotfiles-backup"/*/; do
+    [ -d "$dir" ] && latest_backup="$dir"
+  done
+
+  if [ -n "$latest_backup" ]; then
+    echo ""
+    echo "Backups found. Newest: $latest_backup"
+    echo "Restore any files you need manually from there."
+  fi
+fi


### PR DESCRIPTION
## Summary
- Extract the symlink path lists from install.sh into a shared symlink-manifest.sh (DRY, no behavior change)
- install.sh now backs up any real (non-symlink) file it's about to replace to `~/.dotfiles-backup/<timestamp>/` before symlinking
- Add uninstall.sh: removes only symlinks that resolve into this repo (real files and foreign symlinks are left untouched), supports `--dry-run`
- Extend the Docker integration test to cover the backup-on-install and uninstall flows

Closes #8

## Test plan
- [x] `docker build -f test/Dockerfile.ubuntu -t dotfiles-test-8 .`
- [x] `docker run --rm dotfiles-test-8 bash test/test-install.sh` → All tests passed!
- [x] `shellcheck -S warning install.sh uninstall.sh symlink-manifest.sh test/test-install.sh` → clean