### PR TITLE
feat: add 1Password-backed secrets scaffold

### DIFF
--- a/.shell-utils/dotfiles-secrets.sh
+++ b/.shell-utils/dotfiles-secrets.sh
@@ -2,6 +2,8 @@
 # dotfiles-secrets: render ~/.zshrc.local from templates/zshrc.local.tpl via `op inject`.
 # Requires the 1Password CLI (`op`) signed in. --force overwrites an existing ~/.zshrc.local.
 set -uo pipefail
+# secret-bearing output: ensure files are born 0600, not chmod-ed after the fact
+umask 077
 
 # -P resolves ~/.shell-utils (a symlink) so the parent is the real repo
 DOTFILES_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && cd .. && pwd)"

--- a/.shell-utils/dotfiles-secrets.sh
+++ b/.shell-utils/dotfiles-secrets.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# dotfiles-secrets: render ~/.zshrc.local from templates/zshrc.local.tpl via `op inject`.
+# Requires the 1Password CLI (`op`) signed in. --force overwrites an existing ~/.zshrc.local.
+set -uo pipefail
+
+# -P resolves ~/.shell-utils (a symlink) so the parent is the real repo
+DOTFILES_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && cd .. && pwd)"
+TEMPLATE="$DOTFILES_DIR/templates/zshrc.local.tpl"
+TARGET="$HOME/.zshrc.local"
+FORCE=0
+[ "${1:-}" = "--force" ] && FORCE=1
+
+if ! command -v op > /dev/null 2>&1; then
+  echo "error: 1Password CLI (op) not found; install it first" >&2
+  exit 1
+fi
+
+if [ ! -f "$TEMPLATE" ]; then
+  echo "error: template not found: $TEMPLATE" >&2
+  exit 1
+fi
+
+if [ -e "$TARGET" ] && [ "$FORCE" -ne 1 ]; then
+  echo "error: $TARGET already exists; re-run with --force to overwrite" >&2
+  exit 1
+fi
+
+if ! op account get > /dev/null 2>&1; then
+  echo "error: not signed in to 1Password CLI; run: eval \"\$(op signin)\"" >&2
+  exit 1
+fi
+
+if [ "$FORCE" -eq 1 ]; then
+  op inject -f -i "$TEMPLATE" -o "$TARGET"
+else
+  op inject -i "$TEMPLATE" -o "$TARGET"
+fi
+chmod 600 "$TARGET"
+echo "rendered $TARGET from $TEMPLATE"

--- a/README.md
+++ b/README.md
@@ -45,6 +45,14 @@ bash install.sh
 
 Machine-specific shell config goes in `~/.zshrc.local` (sourced last, never tracked here).
 
+### Secrets
+
+Machine-local secrets also live in `~/.zshrc.local`, generated from
+[`templates/zshrc.local.tpl`](templates/zshrc.local.tpl) by running
+`dotfiles-secrets.sh` (on `PATH` after `install.sh`). Rendering requires a
+signed-in [1Password CLI](https://developer.1password.com/docs/cli/) (`op`);
+the resulting file is never tracked by this repo.
+
 ## Key Tools
 
 - **Shell**: Zsh with [Zinit](https://github.com/zdharma-continuum/zinit) (lazy-loaded plugins)

--- a/templates/zshrc.local.tpl
+++ b/templates/zshrc.local.tpl
@@ -1,0 +1,8 @@
+# Template for ~/.zshrc.local, rendered by `dotfiles-secrets.sh` via `op inject`.
+# ~/.zshrc.local is untracked and sourced last by .zshrc — put machine-local
+# secrets here instead of committing them to this repo.
+#
+# Uncomment and edit with real op:// references, e.g.:
+# export EXAMPLE_TOKEN="{{ op://Private/example-item/credential }}"
+# export EXAMPLE_API_KEY="{{ op://Private/example-item/api-key }}"
+# export EXAMPLE_DB_PASSWORD="{{ op://Private/example-item/password }}"


### PR DESCRIPTION
- Add `templates/zshrc.local.tpl` (generic op:// example, no real refs)
- Add `.shell-utils/dotfiles-secrets.sh` to render it into `~/.zshrc.local` via `op inject` (guards for missing `op`, missing template, not-signed-in, refuse-overwrite)
- Document the flow in README's Setup section

Closes #13

Test plan:
- [x] `shellcheck -S warning` on the new script passes
- [x] `op` removed from PATH + temp `HOME` -> "op not found" guard
- [x] temp `HOME` with pre-existing dummy `~/.zshrc.local` and no `--force` -> refuse-to-overwrite guard
- [x] `op` present + temp `HOME` -> not-signed-in guard (no sign-in attempted)
- [ ] user fills in real op:// refs and verifies rendered `~/.zshrc.local`