### PR TITLE
feat: add gvim to open a ghq repo in nvim

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -243,6 +243,14 @@ if command -v gh &>/dev/null; then
   alias gpo='git-pr-open'
 fi
 alias gcode='${OPEN_BY_MY_EDITOR} $(ghq root)/$(ghq list | fzf --preview "bat --color=always --style=header,grid --line-range :80 $(ghq root)/{}/README.*")'
+# gvim: pick a ghq repo with fzf, cd into it, and open nvim (shell stays there on exit)
+if command -v nvim &>/dev/null; then
+  function gvim() {
+    local repo
+    repo="$(ghq list | fzf --preview "bat --color=always --style=header,grid --line-range :80 $(ghq root)/{}/README.*")" || return
+    [ -n "$repo" ] && builtin cd -- "$(ghq root)/$repo" && nvim
+  }
+fi
 
 alias d='docker'
 alias dc='docker-compose'


### PR DESCRIPTION
## Summary
`gvim` = the nvim counterpart of `gcode`: pick a ghq repo with fzf (same README preview), `cd` into it, launch nvim. The shell stays in the repo after quitting nvim (bonus `gcd` effect). Guarded with `command -v nvim`; uses `builtin cd` to stay out of enhancd's way.

Refs #21.

## Test plan
- [x] `zsh -n .zshrc`
- [ ] After merge: `source ~/.zshrc` (or new pane) → `gvim` → pick a repo → LazyVim opens at repo root; `:q` leaves the shell in the repo