### PR TITLE
feat: エージェントハーネスの稼働状態をdoctorで検知する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: shellcheck
-        run: shellcheck -S warning install.sh test/test-install.sh .shell-utils/*.sh
+        run: shellcheck -S warning install.sh test/test-install.sh test/test-dotfiles-doctor.sh .shell-utils/*.sh
+      - name: Test dotfiles doctor
+        run: bash test/test-dotfiles-doctor.sh
+      - name: Test tool-output compaction
+        run: python3 -m unittest claude/hooks/tests/test_compact_tool_output.py
 
   validate-configs:
     runs-on: ubuntu-latest

--- a/.shell-utils/dotfiles-doctor.sh
+++ b/.shell-utils/dotfiles-doctor.sh
@@ -1,73 +1,334 @@
 #!/usr/bin/env bash
 # dotfiles-doctor: report drift between this repo and the machine.
-# Checks: broken symlinks, Brewfile coverage, agent-skill coverage, dirty repo.
-# --notify: additionally raise a macOS notification when warnings are found
-# (used by the weekly launchd agent).
+# --notify: additionally raise a macOS notification when warnings are found.
+# --harness-only: check only the Claude/Headroom agent harness.
 set -uo pipefail
 
-# -P resolves ~/.shell-utils (a symlink) so the parent is the real repo
+# -P resolves ~/.shell-utils (a symlink) so the parent is the real repo.
 DOTFILES_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && cd .. && pwd)"
 NOTIFY=0
-[ "${1:-}" = "--notify" ] && NOTIFY=1
+HARNESS_ONLY=0
 WARNINGS=0
+HARNESS_WINDOW_DAYS=7
 
 warn() {
   printf '  WARN: %s\n' "$*"
   WARNINGS=$((WARNINGS + 1))
 }
 
-section_ok() {
-  [ "$WARNINGS" -eq "$1" ] && printf '  ok\n'
+info() {
+  printf '  %s\n' "$*"
 }
 
-echo "== broken symlinks (~/, ~/.config, ~/.claude, VS Code) =="
-before=$WARNINGS
-while IFS= read -r link; do
-  warn "broken symlink: $link"
-done < <(
-  find "$HOME" -maxdepth 1 -name ".*" -type l ! -exec test -e {} \; -print 2>/dev/null
-  find "$HOME/.config" "$HOME/.claude" "$HOME/Library/Application Support/Code/User" \
-    -maxdepth 3 -type l ! -exec test -e {} \; -print 2>/dev/null
-)
-section_ok "$before"
-
-echo "== brew leaves not in Brewfile =="
-before=$WARNINGS
-if command -v brew > /dev/null 2>&1; then
-  while IFS= read -r formula; do
-    [ -n "$formula" ] && warn "installed but untracked: $formula"
-  done < <(comm -23 <(brew leaves | sort) \
-    <(grep '^brew "' "$DOTFILES_DIR/Brewfile" | perl -pe 's/^brew "([^"]+)".*/$1/; s|.*/||' | sort))
-fi
-section_ok "$before"
-
-echo "== agent skills not restored by install.sh =="
-before=$WARNINGS
-for dir in "$HOME/.agents/skills"/*/; do
-  [ -d "$dir" ] || continue
-  name=$(basename "$dir")
-  grep -q ":${name}\"" "$DOTFILES_DIR/install.sh" ||
-    warn "skill not in setup_agent_skills: $name"
-done
-section_ok "$before"
-
-echo "== dotfiles repo state =="
-before=$WARNINGS
-if git -C "$DOTFILES_DIR" status --porcelain 2>/dev/null | grep -q .; then
-  warn "uncommitted changes in $DOTFILES_DIR"
-fi
-if [ -n "$(git -C "$DOTFILES_DIR" log --oneline '@{upstream}..HEAD' 2>/dev/null)" ]; then
-  warn "unpushed commits in $DOTFILES_DIR"
-fi
-section_ok "$before"
-
-echo
-if [ "$WARNINGS" -eq 0 ]; then
-  echo "doctor: all clear"
-else
-  echo "doctor: $WARNINGS warning(s)"
-  if [ "$NOTIFY" -eq 1 ] && command -v osascript > /dev/null 2>&1; then
-    osascript -e "display notification \"$WARNINGS warning(s) — run dotfiles-doctor.sh\" with title \"dotfiles-doctor\"" > /dev/null 2>&1 || :
+section_ok() {
+  if [ "$WARNINGS" -eq "$1" ]; then
+    printf '  ok\n'
   fi
-  exit 1
+}
+
+has_command() {
+  command -v "$1" > /dev/null 2>&1
+}
+
+strip_ansi() {
+  LC_ALL=C sed $'s/\033\\[[0-9;]*m//g'
+}
+
+semver_from() {
+  grep -Eo '[0-9]+\.[0-9]+\.[0-9]+' | head -n 1 || :
+}
+
+stats_value() {
+  local key="$1" stats="$2"
+  printf '%s\n' "$stats" | sed -n "s/^${key}: //p" | head -n 1
+}
+
+headroom_deployment_configured() {
+  [ -f "$HOME/.headroom/deploy/default/manifest.json" ]
+}
+
+run_headroom_status() {
+  headroom install status --profile default
+}
+
+run_headroom_savings() {
+  headroom output-savings
+}
+
+run_claude_mcp_list() {
+  claude mcp list
+}
+
+run_claude_version() {
+  claude --version
+}
+
+run_claude_latest_version() {
+  npm view @anthropic-ai/claude-code version
+}
+
+compactor_hook_configured() {
+  grep -Fq 'compact-tool-output.py' "$HOME/.claude/settings.json" 2> /dev/null
+}
+
+run_compactor_stats() {
+  python3 "$DOTFILES_DIR/claude/hooks/compact-tool-output.py" \
+    stats --days "$HARNESS_WINDOW_DAYS"
+}
+
+check_headroom() {
+  echo "== Headroom proxy =="
+  local before=$WARNINGS
+  local output status healthy savings requests saved reduction
+
+  if ! has_command headroom; then
+    warn "Headroom is not installed; next: rerun install.sh"
+  elif ! headroom_deployment_configured; then
+    warn "Headroom Claude deployment is missing; next: rerun install.sh"
+  else
+    if output=$(run_headroom_status 2>&1); then
+      status=$(printf '%s\n' "$output" | sed -n 's/^Status:[[:space:]]*//p' | head -n 1)
+      healthy=$(printf '%s\n' "$output" | sed -n 's/^Healthy:[[:space:]]*//p' | head -n 1)
+      if [[ "$status" == *running* && "$healthy" == yes* ]]; then
+        info "deployment is running and proxy is reachable"
+      elif [[ "$status" != *running* && "$healthy" == yes* ]]; then
+        warn "Persistent Headroom deployment is stopped while a temporary proxy is reachable; next: close headroom wrap sessions, then run install.sh --headroom-only"
+      elif [[ "$status" == *running* ]]; then
+        warn "Headroom deployment is running but its proxy is unreachable; next: run headroom doctor"
+      else
+        warn "Headroom is stopped or its proxy is unreachable; next: run install.sh --headroom-only, then headroom doctor"
+      fi
+    else
+    warn "Headroom status check failed; next: run headroom doctor"
+    fi
+
+    if savings=$(run_headroom_savings 2>&1); then
+      if [[ "$savings" == *"No shaped requests recorded yet."* ]]; then
+        info "output shaper: 0 shaped requests recorded"
+      else
+        requests=$(printf '%s\n' "$savings" | sed -n 's/^[[:space:]]*Requests:[[:space:]]*//p' | head -n 1)
+        saved=$(printf '%s\n' "$savings" | sed -n 's/^[[:space:]]*Saved:[[:space:]]*//p' | head -n 1)
+        reduction=$(printf '%s\n' "$savings" | sed -n 's/^[[:space:]]*Reduction:[[:space:]]*//p' | head -n 1)
+        if [ -n "$requests" ]; then
+          info "output shaper: $requests; ${saved:-saved amount unavailable}; ${reduction:-reduction unavailable}"
+        else
+          info "output shaper: data exists; next: run headroom output-savings for details"
+        fi
+      fi
+    else
+      warn "Headroom output-savings check failed; next: run headroom output-savings"
+    fi
+  fi
+  section_ok "$before"
+}
+
+check_mcp_servers() {
+  echo "== Claude MCP servers =="
+  local before=$WARNINGS
+  local output plain name line
+  local rows=0 connected=0
+
+  if ! has_command claude; then
+    warn "Claude Code is not installed; next: rerun install.sh"
+  elif output=$(run_claude_mcp_list 2>&1); then
+    while IFS= read -r line; do
+      plain=$(printf '%s\n' "$line" | strip_ansi)
+      [[ "$plain" == *" - "* ]] || continue
+      rows=$((rows + 1))
+      name=$(printf '%s\n' "$plain" | sed 's/: .* - .*$/ /; s/^[[:space:]]*//; s/[[:space:]]*$//')
+      [ -n "$name" ] || name="unknown"
+      if [[ "$plain" == *Connected* ]]; then
+        connected=$((connected + 1))
+      else
+        warn "MCP server '$name' is not connected; next: run claude mcp list and inspect that server"
+      fi
+    done <<< "$output"
+
+    if [ "$rows" -eq 0 ]; then
+      warn "Claude MCP check returned no server status; next: run claude mcp list"
+    elif [ "$rows" -eq "$connected" ]; then
+      info "$connected MCP server(s) connected"
+    fi
+  else
+    warn "Claude MCP status check failed; next: run claude mcp list"
+  fi
+  section_ok "$before"
+}
+
+check_claude_version() {
+  echo "== Claude Code version =="
+  local before=$WARNINGS
+  local local_output latest_output local_version latest_version
+
+  if ! has_command claude; then
+    warn "Claude Code is not installed; next: rerun install.sh"
+  elif local_output=$(run_claude_version 2>&1); then
+    local_version=$(printf '%s\n' "$local_output" | semver_from)
+    if [ -z "$local_version" ]; then
+      warn "Claude Code version could not be parsed; next: run claude --version"
+    elif ! has_command npm; then
+      warn "npm is unavailable, so the latest Claude Code version cannot be checked; next: rerun install.sh"
+    elif latest_output=$(run_claude_latest_version 2>&1); then
+      latest_version=$(printf '%s\n' "$latest_output" | semver_from)
+      if [ -z "$latest_version" ]; then
+        warn "Latest Claude Code version could not be parsed; next: run npm view @anthropic-ai/claude-code version"
+      elif [ "$local_version" = "$latest_version" ]; then
+        info "installed $local_version; latest stable $latest_version"
+      else
+        warn "Claude Code installed $local_version; latest stable $latest_version; next: run claude update"
+      fi
+    else
+      warn "Latest Claude Code version check failed; next: run npm view @anthropic-ai/claude-code version"
+    fi
+  else
+    warn "Claude Code version check failed; next: run claude --version"
+  fi
+  section_ok "$before"
+}
+
+check_tool_output_compaction() {
+  echo "== Claude tool-output compaction (last ${HARNESS_WINDOW_DAYS} days) =="
+  local before=$WARNINGS
+  local stats active last_invoked failures archives saved
+  local script="$DOTFILES_DIR/claude/hooks/compact-tool-output.py"
+
+  if [ ! -f "$script" ]; then
+    warn "Compaction hook script is missing; next: rerun install.sh"
+  elif ! compactor_hook_configured; then
+    warn "Compaction hook is not configured in Claude settings; next: rerun install.sh"
+  elif ! has_command python3; then
+    warn "python3 is unavailable, so compaction health cannot be checked; next: rerun install.sh"
+  elif stats=$(run_compactor_stats 2>&1); then
+    active=$(stats_value "hook active" "$stats")
+    last_invoked=$(stats_value "hook last invoked" "$stats")
+    failures=$(stats_value "hook failures" "$stats")
+    archives=$(stats_value "archives" "$stats")
+    saved=$(stats_value "saved" "$stats")
+
+    if [ "$active" = "yes" ]; then
+      info "hook active; last invoked ${last_invoked:-unknown}"
+      if [ "$archives" = "0" ]; then
+        info "0 compactions is healthy: no supported output crossed the threshold"
+      fi
+    else
+      warn "Compaction hook was not observed in ${HARNESS_WINDOW_DAYS} days; next: use a Read/Grep/Glob/Web/MCP tool, then rerun compact-tool-output.py stats"
+    fi
+
+    case "$failures" in
+      '' | *[!0-9]*)
+        warn "Compaction failure count could not be parsed; next: rerun compact-tool-output.py stats"
+        ;;
+      0) ;;
+      *)
+        warn "$failures compaction hook failure(s) in ${HARNESS_WINDOW_DAYS} days; next: inspect Claude hook stderr and run the hook tests"
+        ;;
+    esac
+
+    if [[ "$archives" =~ ^[0-9]+$ && -n "$saved" ]]; then
+      info "${archives} compaction(s), saved $saved"
+    else
+      warn "Compaction savings could not be parsed; next: rerun compact-tool-output.py stats"
+    fi
+  else
+    warn "Compaction stats failed; next: run python3 ~/.claude/hooks/compact-tool-output.py stats"
+  fi
+  section_ok "$before"
+}
+
+check_agent_harness() {
+  check_headroom
+  check_mcp_servers
+  check_claude_version
+  check_tool_output_compaction
+}
+
+check_local_drift() {
+  echo "== broken symlinks (~/, ~/.config, ~/.claude, VS Code) =="
+  local before=$WARNINGS
+  local name dir formula link
+  while IFS= read -r link; do
+    warn "broken symlink: $link"
+  done < <(
+    find "$HOME" -maxdepth 1 -name ".*" -type l ! -exec test -e {} \; -print 2> /dev/null
+    find "$HOME/.config" "$HOME/.claude" "$HOME/Library/Application Support/Code/User" \
+      -maxdepth 3 -type l ! -exec test -e {} \; -print 2> /dev/null
+  )
+  section_ok "$before"
+
+  echo "== brew leaves not in Brewfile =="
+  before=$WARNINGS
+  if has_command brew; then
+    while IFS= read -r formula; do
+      [ -n "$formula" ] && warn "installed but untracked: $formula"
+    done < <(comm -23 <(brew leaves | sort) \
+      <(grep '^brew "' "$DOTFILES_DIR/Brewfile" | perl -pe 's/^brew "([^"]+)".*/$1/; s|.*/||' | sort))
+  fi
+  section_ok "$before"
+
+  echo "== agent skills not restored by install.sh =="
+  before=$WARNINGS
+  for dir in "$HOME/.agents/skills"/*/; do
+    [ -d "$dir" ] || continue
+    name=$(basename "$dir")
+    grep -q ":${name}\"" "$DOTFILES_DIR/install.sh" ||
+      warn "skill not in setup_agent_skills: $name"
+  done
+  section_ok "$before"
+
+  echo "== dotfiles repo state =="
+  before=$WARNINGS
+  if git -C "$DOTFILES_DIR" status --porcelain 2> /dev/null | grep -q .; then
+    warn "uncommitted changes in $DOTFILES_DIR"
+  fi
+  if [ -n "$(git -C "$DOTFILES_DIR" log --oneline '@{upstream}..HEAD' 2> /dev/null)" ]; then
+    warn "unpushed commits in $DOTFILES_DIR"
+  fi
+  section_ok "$before"
+}
+
+parse_options() {
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --notify) NOTIFY=1 ;;
+      --harness-only) HARNESS_ONLY=1 ;;
+      -h | --help)
+        echo "usage: dotfiles-doctor.sh [--notify] [--harness-only]"
+        return 2
+        ;;
+      *)
+        printf 'unknown option: %s\n' "$1" >&2
+        return 2
+        ;;
+    esac
+    shift
+  done
+}
+
+finish() {
+  echo
+  if [ "$WARNINGS" -eq 0 ]; then
+    echo "doctor: all clear"
+    return 0
+  fi
+
+  echo "doctor: $WARNINGS warning(s)"
+  info "full harness diagnostics: ~/.shell-utils/dotfiles-doctor.sh --harness-only"
+  if [ "$NOTIFY" -eq 1 ] && has_command osascript; then
+    osascript -e "display notification \"$WARNINGS warning(s) — run dotfiles-doctor.sh --harness-only\" with title \"dotfiles-doctor\"" > /dev/null 2>&1 || :
+  fi
+  return 1
+}
+
+main() {
+  parse_options "$@" || return $?
+  printf 'dotfiles doctor: %s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+  if [ "$HARNESS_ONLY" -eq 0 ]; then
+    check_local_drift
+  fi
+  check_agent_harness
+  finish
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  main "$@"
 fi

--- a/README.md
+++ b/README.md
@@ -97,11 +97,15 @@ Large Read, Grep, Glob, Web, and MCP results are shortened before entering the
 conversation. The full result is retained locally for seven days with user-only
 permissions and can be queried through the `expand-tool-output` skill.
 
-Show aggregate savings:
+Show health and savings for the last seven days:
 
 ```bash
 python3 ~/.claude/hooks/compact-tool-output.py stats
 ```
+
+The report distinguishes an active hook with zero threshold crossings from a
+hook that has not run, and counts fail-open hook errors without storing error
+messages or tool payloads.
 
 ## Headroom Proxy
 
@@ -123,6 +127,21 @@ Check the proxy and output-shaping savings:
 headroom install status
 headroom doctor
 headroom output-savings
+```
+
+Run the complete agent-harness diagnostic (Headroom reachability, MCP
+connections, Claude Code version drift, and tool-output compaction):
+
+```bash
+~/.shell-utils/dotfiles-doctor.sh --harness-only
+```
+
+If Docker is unavailable, rerunning `install.sh` migrates an existing Docker
+deployment to Headroom's native scheduled recovery instead of leaving a stale
+container deployment behind.
+
+```bash
+./install.sh --headroom-only
 ```
 
 ## Configuration Storage Strategy

--- a/claude/hooks/compact-tool-output.py
+++ b/claude/hooks/compact-tool-output.py
@@ -11,6 +11,7 @@ import json
 import os
 from pathlib import Path
 import re
+import stat
 import sys
 import time
 from typing import Any
@@ -25,6 +26,9 @@ ERROR_LINE = re.compile(
 DEFAULT_MAX_CHARS = 40_000
 DEFAULT_PREVIEW_CHARS = 12_000
 DEFAULT_RETENTION_DAYS = 7
+DEFAULT_HEALTH_TOUCH_SECONDS = 300
+LAST_INVOKED_FILE = ".last-invoked"
+ERROR_DIR = ".errors"
 
 
 def env_int(name: str, default: int, minimum: int) -> int:
@@ -198,6 +202,77 @@ def prepare_cache(root: Path) -> None:
     os.chmod(root, 0o700)
 
 
+def mark_hook_invoked(root: Path) -> None:
+    """Record supported hook traffic without retaining tool input or output."""
+    prepare_cache(root)
+    marker = root / LAST_INVOKED_FILE
+    interval = env_int(
+        "CLAUDE_TOOL_OUTPUT_HEALTH_TOUCH_SECONDS",
+        DEFAULT_HEALTH_TOUCH_SECONDS,
+        1,
+    )
+    try:
+        marker_stat = marker.stat(follow_symlinks=False)
+        if stat.S_ISREG(marker_stat.st_mode) and time.time() - marker_stat.st_mtime < interval:
+            return
+    except FileNotFoundError:
+        pass
+
+    flags = os.O_WRONLY | os.O_CREAT
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    descriptor = os.open(marker, flags, 0o600)
+    try:
+        os.fchmod(descriptor, 0o600)
+        os.utime(descriptor)
+    finally:
+        os.close(descriptor)
+    retention_days = env_int(
+        "CLAUDE_TOOL_OUTPUT_RETENTION_DAYS", DEFAULT_RETENTION_DAYS, 1
+    )
+    clean_expired_archives(root, retention_days)
+    clean_expired_errors(root, retention_days)
+
+
+def clean_expired_errors(root: Path, retention_days: int) -> None:
+    errors = root / ERROR_DIR
+    if not errors.is_dir() or errors.is_symlink():
+        return
+    cutoff = time.time() - retention_days * 86_400
+    for path in errors.glob("*.json"):
+        try:
+            if path.is_file() and not path.is_symlink() and path.stat().st_mtime < cutoff:
+                path.unlink()
+        except OSError:
+            continue
+
+
+def record_hook_error(root: Path, error: Exception) -> None:
+    """Record only failure metadata; exception text may contain sensitive data."""
+    prepare_cache(root)
+    errors = root / ERROR_DIR
+    prepare_cache(errors)
+    retention_days = env_int(
+        "CLAUDE_TOOL_OUTPUT_RETENTION_DAYS", DEFAULT_RETENTION_DAYS, 1
+    )
+    clean_expired_errors(root, retention_days)
+    path = errors / f"{time.time_ns()}-{os.getpid()}.json"
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    descriptor = os.open(path, flags, 0o600)
+    with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+        json.dump(
+            {
+                "version": 1,
+                "created_at": datetime.now(UTC).isoformat(),
+                "error_type": type(error).__name__,
+            },
+            stream,
+        )
+        stream.write("\n")
+
+
 def clean_expired_archives(root: Path, retention_days: int) -> None:
     cutoff = time.time() - retention_days * 86_400
     for path in root.glob("*.json"):
@@ -241,6 +316,8 @@ def run_hook() -> int:
         if not SUPPORTED_TOOL.fullmatch(tool_name) or "tool_response" not in payload:
             return 0
 
+        root = cache_dir()
+        mark_hook_invoked(root)
         response = payload["tool_response"]
         original_chars = len(encode(response))
         max_chars = env_int("CLAUDE_TOOL_OUTPUT_MAX_CHARS", DEFAULT_MAX_CHARS, 256)
@@ -259,8 +336,6 @@ def run_hook() -> int:
         if compacted_chars >= original_chars:
             return 0
 
-        root = cache_dir()
-        prepare_cache(root)
         clean_expired_archives(
             root,
             env_int("CLAUDE_TOOL_OUTPUT_RETENTION_DAYS", DEFAULT_RETENTION_DAYS, 1),
@@ -286,7 +361,11 @@ def run_hook() -> int:
         )
         return 0
     except Exception as error:  # Hooks must fail open.
-        print(f"compact-tool-output: {error}", file=sys.stderr)
+        try:
+            record_hook_error(cache_dir(), error)
+        except Exception:
+            pass
+        print(f"compact-tool-output: {type(error).__name__}", file=sys.stderr)
         return 0
 
 
@@ -349,23 +428,56 @@ def expand_archive(args: argparse.Namespace) -> int:
     return 0
 
 
-def show_stats() -> int:
+def show_stats(days: int) -> int:
     root = cache_dir()
+    days = max(days, 1)
+    cutoff = time.time() - days * 86_400
     archives: list[dict[str, Any]] = []
     if root.exists():
         for path in root.glob("*.json"):
             if path.is_symlink():
                 continue
             try:
+                if path.stat().st_mtime < cutoff:
+                    continue
                 with path.open(encoding="utf-8") as stream:
                     archives.append(json.load(stream))
             except (OSError, json.JSONDecodeError):
+                continue
+
+    last_invoked: float | None = None
+    marker = root / LAST_INVOKED_FILE
+    try:
+        marker_stat = marker.stat(follow_symlinks=False)
+        if stat.S_ISREG(marker_stat.st_mode):
+            last_invoked = marker_stat.st_mtime
+    except OSError:
+        pass
+
+    failures = 0
+    errors = root / ERROR_DIR
+    if errors.is_dir() and not errors.is_symlink():
+        for path in errors.glob("*.json"):
+            try:
+                if path.is_file() and not path.is_symlink() and path.stat().st_mtime >= cutoff:
+                    failures += 1
+            except OSError:
                 continue
 
     original = sum(int(item.get("original_chars", 0)) for item in archives)
     compacted = sum(int(item.get("compacted_chars", 0)) for item in archives)
     saved = max(original - compacted, 0)
     percent = saved * 100 / original if original else 0
+    active = last_invoked is not None and last_invoked >= cutoff
+    last_invoked_text = (
+        datetime.fromtimestamp(last_invoked, UTC).isoformat().replace("+00:00", "Z")
+        if last_invoked is not None
+        else "never"
+    )
+    print(f"window: {days} days")
+    print(f"hook active: {'yes' if active else 'no'}")
+    print(f"hook last invoked: {last_invoked_text}")
+    print(f"hook failures: {failures}")
     print(f"archives: {len(archives)}")
     print(f"original chars: {original:,}")
     print(f"compacted chars: {compacted:,}")
@@ -382,7 +494,8 @@ def parse_args() -> argparse.Namespace:
     expand.add_argument("--context", type=int, default=2)
     expand.add_argument("--head", type=int, default=0)
     expand.add_argument("--tail", type=int, default=0)
-    subparsers.add_parser("stats", help="show local compaction savings")
+    stats_parser = subparsers.add_parser("stats", help="show local compaction savings")
+    stats_parser.add_argument("--days", type=int, default=DEFAULT_RETENTION_DAYS)
     return parser.parse_args()
 
 
@@ -391,7 +504,7 @@ def main() -> int:
     if args.command == "expand":
         return expand_archive(args)
     if args.command == "stats":
-        return show_stats()
+        return show_stats(args.days)
     return run_hook()
 
 

--- a/claude/hooks/tests/test_compact_tool_output.py
+++ b/claude/hooks/tests/test_compact_tool_output.py
@@ -6,6 +6,7 @@ import stat
 import subprocess
 import sys
 import tempfile
+import time
 import unittest
 
 
@@ -37,6 +38,16 @@ class CompactToolOutputTest(unittest.TestCase):
             check=False,
         )
 
+    def run_raw_hook(self, payload: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [sys.executable, str(SCRIPT)],
+            input=payload,
+            text=True,
+            capture_output=True,
+            env=self.env,
+            check=False,
+        )
+
     def archive_id_from(self, output: dict) -> str:
         encoded = json.dumps(output, ensure_ascii=False)
         match = re.search(r"archive ([a-f0-9]{20})", encoded)
@@ -56,7 +67,10 @@ class CompactToolOutputTest(unittest.TestCase):
 
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertEqual(result.stdout, "")
-        self.assertFalse(self.cache_dir.exists())
+        marker = self.cache_dir / ".last-invoked"
+        self.assertTrue(marker.is_file())
+        self.assertEqual(stat.S_IMODE(marker.stat().st_mode), 0o600)
+        self.assertEqual(list(self.cache_dir.glob("*.json")), [])
 
     def test_compacts_large_output_and_archives_the_original(self) -> None:
         original_response = {
@@ -188,8 +202,89 @@ class CompactToolOutputTest(unittest.TestCase):
         )
 
         self.assertEqual(stats_result.returncode, 0, stats_result.stderr)
+        self.assertIn("window: 7 days", stats_result.stdout)
+        self.assertIn("hook active: yes", stats_result.stdout)
+        self.assertIn("hook failures: 0", stats_result.stdout)
         self.assertIn("archives: 1", stats_result.stdout)
         self.assertRegex(stats_result.stdout, r"saved: [1-9][0-9,]* chars")
+
+    def test_stats_distinguishes_active_hook_with_no_compactions(self) -> None:
+        hook_result = self.run_hook(
+            {
+                "session_id": "session-6",
+                "tool_use_id": "tool-7",
+                "tool_name": "Read",
+                "tool_response": {"content": "small"},
+            }
+        )
+        self.assertEqual(hook_result.returncode, 0, hook_result.stderr)
+
+        stats_result = subprocess.run(
+            [sys.executable, str(SCRIPT), "stats", "--days", "7"],
+            text=True,
+            capture_output=True,
+            env=self.env,
+            check=False,
+        )
+
+        self.assertEqual(stats_result.returncode, 0, stats_result.stderr)
+        self.assertIn("hook active: yes", stats_result.stdout)
+        self.assertNotIn("hook last invoked: never", stats_result.stdout)
+        self.assertIn("hook failures: 0", stats_result.stdout)
+        self.assertIn("archives: 0", stats_result.stdout)
+
+    def test_records_failure_metadata_without_payload_content(self) -> None:
+        secret = "credential-do-not-log"
+        result = self.run_raw_hook("{" + secret)
+
+        self.assertEqual(result.returncode, 0)
+        self.assertNotIn(secret, result.stderr)
+        error_files = list((self.cache_dir / ".errors").glob("*.json"))
+        self.assertEqual(len(error_files), 1)
+        error_record = json.loads(error_files[0].read_text())
+        self.assertEqual(error_record["error_type"], "JSONDecodeError")
+        self.assertNotIn(secret, json.dumps(error_record))
+
+        stats_result = subprocess.run(
+            [sys.executable, str(SCRIPT), "stats"],
+            text=True,
+            capture_output=True,
+            env=self.env,
+            check=False,
+        )
+        self.assertIn("hook active: no", stats_result.stdout)
+        self.assertIn("hook failures: 1", stats_result.stdout)
+
+    def test_stats_excludes_archives_and_failures_older_than_window(self) -> None:
+        hook_result = self.run_hook(
+            {
+                "session_id": "session-7",
+                "tool_use_id": "tool-8",
+                "tool_name": "Glob",
+                "tool_response": {"filenames": "old.txt\n" * 500},
+            }
+        )
+        self.assertEqual(hook_result.returncode, 0, hook_result.stderr)
+        error_result = self.run_raw_hook("{old-invalid-json")
+        self.assertEqual(error_result.returncode, 0)
+
+        old_timestamp = time.time() - 8 * 86_400
+        archive_path = next(self.cache_dir.glob("*.json"))
+        error_path = next((self.cache_dir / ".errors").glob("*.json"))
+        os.utime(archive_path, (old_timestamp, old_timestamp))
+        os.utime(error_path, (old_timestamp, old_timestamp))
+
+        stats_result = subprocess.run(
+            [sys.executable, str(SCRIPT), "stats", "--days", "7"],
+            text=True,
+            capture_output=True,
+            env=self.env,
+            check=False,
+        )
+        self.assertEqual(stats_result.returncode, 0, stats_result.stderr)
+        self.assertIn("hook active: yes", stats_result.stdout)
+        self.assertIn("hook failures: 0", stats_result.stdout)
+        self.assertIn("archives: 0", stats_result.stdout)
 
     def test_expand_rejects_an_invalid_archive_id(self) -> None:
         result = subprocess.run(

--- a/install.sh
+++ b/install.sh
@@ -340,24 +340,6 @@ setup_headroom() {
   fi
 
   local manifest="$HOME/.headroom/deploy/default/manifest.json"
-  if [ -f "$manifest" ] \
-    && jq -e \
-      '.provider_mode == "manual"
-       and .targets == ["claude"]
-       and .base_env.HEADROOM_ROLLOUT_CHANNEL == "beta"
-       and .base_env.HEADROOM_OUTPUT_SHAPER == "1"' \
-      "$manifest" > /dev/null 2>&1; then
-    echo "  exists: Headroom persistent Claude deployment"
-    if ! headroom install status --profile default 2>/dev/null | grep -q '^Status:.*running'; then
-      if jq -e '.preset == "persistent-task"' "$manifest" > /dev/null 2>&1; then
-        echo "  waiting for Headroom scheduled recovery"
-      else
-        headroom install start --profile default || echo "  failed: start Headroom deployment"
-      fi
-    fi
-    return 0
-  fi
-
   local preset runtime
   if command -v docker > /dev/null 2>&1 && docker info > /dev/null 2>&1; then
     preset=persistent-docker
@@ -365,6 +347,32 @@ setup_headroom() {
   else
     preset=persistent-task
     runtime=python
+  fi
+
+  if [ -f "$manifest" ] \
+    && jq -e --arg preset "$preset" --arg runtime "$runtime" \
+      '.provider_mode == "manual"
+       and .targets == ["claude"]
+       and .preset == $preset
+       and .runtime_kind == $runtime
+       and .base_env.HEADROOM_ROLLOUT_CHANNEL == "beta"
+       and .base_env.HEADROOM_OUTPUT_SHAPER == "1"' \
+      "$manifest" > /dev/null 2>&1; then
+    echo "  exists: Headroom persistent Claude deployment ($preset)"
+    if ! headroom install status --profile default 2>/dev/null | grep -q '^Status:.*running'; then
+      if jq -e '.preset == "persistent-task"' "$manifest" > /dev/null 2>&1; then
+        if [ -x "$HOME/.headroom/deploy/default/ensure-headroom.sh" ]; then
+          echo "  recovering Headroom with scheduled-task watchdog"
+          "$HOME/.headroom/deploy/default/ensure-headroom.sh" ||
+            echo "  failed: Headroom scheduled-task recovery"
+        else
+          echo "  waiting for Headroom scheduled recovery"
+        fi
+      else
+        headroom install start --profile default || echo "  failed: start Headroom deployment"
+      fi
+    fi
+    return 0
   fi
 
   echo "----------------------------------------------"
@@ -629,6 +637,15 @@ if [ "${1:-}" = "--symlinks-only" ]; then
   echo ""
   echo "=========================================="
   echo "Symlink setup complete!"
+  echo "=========================================="
+  exit 0
+fi
+
+if [ "${1:-}" = "--headroom-only" ]; then
+  setup_headroom
+  echo ""
+  echo "=========================================="
+  echo "Headroom setup complete!"
   echo "=========================================="
   exit 0
 fi

--- a/test/test-dotfiles-doctor.sh
+++ b/test/test-dotfiles-doctor.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$TEST_DIR/.." && pwd)"
+# shellcheck source=../.shell-utils/dotfiles-doctor.sh
+source "$REPO_DIR/.shell-utils/dotfiles-doctor.sh"
+
+TEST_OUTPUT_DIR=$(mktemp -d)
+trap 'rm -rf "$TEST_OUTPUT_DIR"' EXIT
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+assert_contains() {
+  local expected="$1" file="$2"
+  grep -Fq "$expected" "$file" || fail "missing output: $expected"
+}
+
+assert_not_contains() {
+  local unexpected="$1" file="$2"
+  if grep -Fq "$unexpected" "$file"; then
+    fail "unexpected output: $unexpected"
+  fi
+}
+
+has_command() {
+  return 0
+}
+
+headroom_deployment_configured() {
+  return 0
+}
+
+compactor_hook_configured() {
+  return 0
+}
+
+run_headroom_status() {
+  printf 'Status: running\nHealthy: yes\n'
+}
+
+run_headroom_savings() {
+  printf 'No shaped requests recorded yet.\n'
+}
+
+run_claude_mcp_list() {
+  printf 'context7: command - ✓ Connected\nserena: command - ✓ Connected\n'
+}
+
+run_claude_version() {
+  printf '2.1.241 (Claude Code)\n'
+}
+
+run_claude_latest_version() {
+  printf '2.1.241\n'
+}
+
+run_compactor_stats() {
+  printf '%s\n' \
+    'window: 7 days' \
+    'hook active: yes' \
+    'hook last invoked: 2026-08-26T00:00:00Z' \
+    'hook failures: 0' \
+    'archives: 0' \
+    'saved: 0 chars (0.0%, about 0 tokens)'
+}
+
+healthy_output="$TEST_OUTPUT_DIR/healthy"
+WARNINGS=0
+check_agent_harness > "$healthy_output"
+[ "$WARNINGS" -eq 0 ] || fail "healthy harness produced $WARNINGS warning(s)"
+assert_contains "2 MCP server(s) connected" "$healthy_output"
+assert_contains "installed 2.1.241; latest stable 2.1.241" "$healthy_output"
+assert_contains "0 compactions is healthy" "$healthy_output"
+
+run_headroom_status() {
+  printf 'Status: stopped\nHealthy: yes\n'
+}
+
+temporary_proxy_output="$TEST_OUTPUT_DIR/temporary-proxy"
+WARNINGS=0
+check_headroom > "$temporary_proxy_output"
+[ "$WARNINGS" -eq 1 ] || fail "temporary proxy conflict produced $WARNINGS warning(s), expected 1"
+assert_contains "temporary proxy is reachable" "$temporary_proxy_output"
+assert_contains "close headroom wrap sessions" "$temporary_proxy_output"
+
+run_headroom_status() {
+  printf 'Status: stopped\nHealthy: no\n'
+}
+
+run_claude_mcp_list() {
+  printf '%s\n' \
+    'context7: command - ✓ Connected' \
+    'serena: command credential-do-not-log - ✗ Failed'
+}
+
+run_claude_version() {
+  printf '2.1.231 (Claude Code)\n'
+}
+
+run_compactor_stats() {
+  printf '%s\n' \
+    'window: 7 days' \
+    'hook active: no' \
+    'hook last invoked: never' \
+    'hook failures: 1' \
+    'archives: 0' \
+    'saved: 0 chars (0.0%, about 0 tokens)'
+}
+
+unhealthy_output="$TEST_OUTPUT_DIR/unhealthy"
+WARNINGS=0
+check_agent_harness > "$unhealthy_output"
+[ "$WARNINGS" -eq 5 ] || fail "unhealthy harness produced $WARNINGS warning(s), expected 5"
+assert_contains "run install.sh --headroom-only" "$unhealthy_output"
+assert_contains "MCP server 'serena' is not connected" "$unhealthy_output"
+assert_contains "Claude Code installed 2.1.231; latest stable 2.1.241" "$unhealthy_output"
+assert_contains "Compaction hook was not observed in 7 days" "$unhealthy_output"
+assert_contains "1 compaction hook failure(s) in 7 days" "$unhealthy_output"
+assert_not_contains "credential-do-not-log" "$unhealthy_output"
+
+printf 'dotfiles-doctor tests: ok\n'


### PR DESCRIPTION
## 概要

- dotfiles-doctor に Headroom deployment と proxy、MCP、Claude Code の版差、tool-output compaction の診断を追加
- compaction hook に直近7日の稼働時刻、圧縮回数、削減量、失敗数を記録し、正常な0件と未稼働を区別
- hook失敗は例外型だけを保存し、tool payload や例外メッセージを診断へ出さない
- Docker が利用できなくなった場合は Headroom を native persistent-task へ移行
- Headroom だけを直せる install.sh --headroom-only を追加
- 週次ログへ実行時刻と各警告の次の操作を出力
- doctor と compaction の回帰テストを CI に追加

## 検証

- shellcheck -S warning install.sh test/test-install.sh test/test-dotfiles-doctor.sh .shell-utils/*.sh
- python3 -m unittest claude/hooks/tests/test_compact_tool_output.py: 10 tests passed
- bash test/test-dotfiles-doctor.sh
- 一時 HOME で bash test/test-install.sh
- 実環境診断で MCP 6件の接続成功、Headroom の一時 proxy と停止中の永続 deployment の競合、Claude Code の版差、compaction hook 未観測を区別できることを確認

Closes #34