### PR TITLE
feat(claude): add ticket skill for Jira/Notion sync

### DIFF
--- a/claude/.gitignore
+++ b/claude/.gitignore
@@ -19,6 +19,9 @@ skills/*
 !skills/delivery-workflow/
 !skills/expand-tool-output/
 !skills/prepare-compaction/
+!skills/ticket/
+# Concrete IDs, board URLs, and option labels stay local: this repo is public
+skills/ticket/reference.md
 statsig/
 tasks/
 teams/

--- a/claude/skills/ticket/SKILL.md
+++ b/claude/skills/ticket/SKILL.md
@@ -10,11 +10,13 @@ this skill must never write to. Claude maintains the Jira issues plus a
 personal Notion staging mirror; the user copies staging rows to the shared
 board manually, about weekly.
 
-`reference.md` sits next to this file and is local-only (untracked). It
+`reference.md` sits next to this file and is machine-local: gitignored and
+absent from the symlink manifest, because this repository is public. It
 holds every concrete identifier: Jira project and board, Notion data
 source IDs, workspace names and IDs, shared-board option labels, the
 linking-only epic title pattern, and the snapshot query. Read it before
-the first Jira or Notion call of a run.
+the first Jira or Notion call of a run. If it is missing, create it from
+`reference.example.md` together with the user instead of guessing values.
 
 ## Systems and workspace mode
 

--- a/claude/skills/ticket/SKILL.md
+++ b/claude/skills/ticket/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: ticket
+description: Create and sync work tickets across a team Jira project and a personal Notion staging board. Use when the user starts a work task that should have a ticket, asks to create a ticket, or asks to sync ticket status between Jira and Notion.
+---
+
+# Ticket (Jira <-> Notion staging)
+
+The team duplicates tickets between Jira and a shared Notion board that
+this skill must never write to. Claude maintains the Jira issues plus a
+personal Notion staging mirror; the user copies staging rows to the shared
+board manually, about weekly.
+
+`reference.md` sits next to this file and is local-only (untracked). It
+holds every concrete identifier: Jira project and board, Notion data
+source IDs, workspace names and IDs, shared-board option labels, the
+linking-only epic title pattern, and the snapshot query. Read it before
+the first Jira or Notion call of a run.
+
+## Systems and workspace mode
+
+- **Jira (writable)**: the project and board named in reference.md, via
+  the `atlassian-http` MCP server.
+- **Notion shared board (read-only)**: the team board data source in
+  reference.md.
+- **Notion staging DB (writable)**: "Ticket Staging" in the user's own
+  workspace.
+
+The Notion connector binds ONE workspace at a time. Before any Notion
+operation, check `notion-fetch self` against the workspace table in
+reference.md:
+
+| Connected workspace | Mode                                                                                      |
+| ------------------- | ----------------------------------------------------------------------------------------- |
+| personal            | normal: staging read/write                                                                |
+| shared team         | read-only: search and snapshot only; queue staging writes and ask the user to switch back |
+
+Snapshot of the user's open shared-board tickets:
+`~/.claude/ticket/shared-board-snapshot-<date>.csv` (newest wins). Refresh
+it whenever the shared workspace happens to be connected (reference.md).
+
+## Entry points
+
+- **Task start (implicit)**: work that warrants a ticket — a feature, fix,
+  or investigation with a deliverable — runs the create workflow. Skip
+  trivial questions, throwaway experiments, and dotfiles/personal chores.
+- **Status change (implicit)**: run the status-change prompt below.
+- **Explicit**: `/ticket create`, `/ticket sync`.
+
+## Create workflow
+
+1. Search Jira, the staging DB, and the snapshot CSV for existing tickets;
+   search the shared board live only when that workspace is connected.
+2. Present plausible candidates. Link to an existing ticket only on user
+   confirmation — a false match is worse than a duplicate.
+3. Propose compactly (title, type, one-line scope, granularity) and wait
+   for approval. Prior in-session agreement on a task breakdown does NOT
+   count as ticket-granularity approval: always re-confirm the granularity
+   at creation time — session decomposition and ticket granularity are
+   different decisions.
+4. Create whichever side is missing; Jira first, so the issue key can go on
+   the staging row.
+5. The full description lives in Jira. The staging page body stays within a
+   few blocks; properties carry the rest. Match the language and section
+   headings of existing issues in the project.
+
+Epics whose titles match the linking-only pattern in reference.md exist
+only to group issues: exclude them from duplicate candidates, sync,
+triage, and reports.
+
+## Sync workflow (`/ticket sync` or when asked)
+
+1. Query staging pages where `Sync State != Copied-Done`.
+2. Reconcile each with its Jira issue: Jira status changes update staging
+   automatically; staging edits by the user (title, estimate, deadline) are
+   offered as one batched Jira update, applied on approval.
+3. Cleanup: archive `Copied-Done` pages without asking — their content
+   survives in Jira and on the shared board (the snapshot covers the lost
+   search corpus; do not "fix" this by keeping them). Remind the user to
+   empty Notion trash occasionally: the API cannot hard-delete, and trashed
+   blocks may still count against the block cap.
+4. Triage stale `Not Started` rows (no update for ~6 weeks and low
+   priority): propose Not Doing / delete / keep per ticket; apply only what
+   the user picks.
+5. Report a compact diff of all changes, plus completed-but-uncopied
+   tickets as "ready to copy".
+
+## Status-change prompt (automatic)
+
+Whenever a ticket's status changes through this skill — a Jira transition,
+a staging update, or tracked work starting or finishing in-session — ask:
+「このチケットは共有ボードに提出済み？」
+
+- Yes with URL: set `Shared Board URL`; `Sync State` = Copied, or
+  Copied-Done when the ticket is done.
+- Yes without URL: `Sync State` = Copied.
+- No: leave as is; it stays on the "ready to copy" list.
+  Ask once per ticket per status change, not repeatedly in one session.
+
+## Staging schema (summary)
+
+Shared-board-compatible: `Title` (title); `Type`, `Status`, `Priority`,
+`Project`, `Section`, `Estimated workload`, `Confidence` (select);
+`Deadline` (date). Exact option labels: reference.md — they are the
+copy-paste contract with the shared board, keep them identical.
+Sync bookkeeping: `Jira Key` (text), `Jira URL` (url), `Shared Board URL`
+(url), `Sync State` (select: Draft / Created / Copied / Copied-Done),
+`Last Synced` (date).
+Status mapping: To Do=Not Started, In Progress=In Progress,
+In Review=Reviewing, Done=Complete; record extra project-specific states
+in reference.md.
+
+## Hard rules
+
+- NEVER write in the shared team workspace.
+- Ticket creation and every Jira write require explicit user approval;
+  automatic staging mirror updates and Copied-Done archiving during sync
+  are exempt.
+- One Jira issue per approved ticket; never bulk-create speculatively.
+- Block budget: the staging workspace is on the Free plan (~1000 blocks).
+  Keep staging bodies minimal; archive what is done.
+- Keep concrete identifiers in reference.md, never in this file: it is
+  published in a public repository.
+- If searches or MCP calls fail twice, stop and report.

--- a/claude/skills/ticket/reference.example.md
+++ b/claude/skills/ticket/reference.example.md
@@ -1,0 +1,74 @@
+# Ticket skill reference (template)
+
+Copy this file to `reference.md` next to it and fill in the real values.
+`reference.md` is machine-local: it is gitignored and deliberately absent
+from `symlink-manifest.sh`, because this repository is public.
+
+## Systems
+
+- **Jira (writable)**: project `<KEY>`, board `<N>` backlog at
+  `<https://<site>.atlassian.net/jira/software/projects/<KEY>/boards/<N>/backlog>`
+  via the `atlassian-http` MCP server. Pass `<site>.atlassian.net` as
+  `cloudId`.
+- **Notion shared board**: `<board name>`, data source
+  `collection://<uuid>` (`<shared workspace name>`).
+- **Notion staging DB**: "Ticket Staging" in the user's own workspace,
+  data source `collection://<uuid>` (database page: `<url>`).
+
+## Workspace table (`notion-fetch self`)
+
+| Connected workspace | ID       | Mode      |
+| ------------------- | -------- | --------- |
+| `<personal>`        | `<uuid>` | normal    |
+| `<shared team>`     | `<uuid>` | read-only |
+
+## Linking-only epics
+
+Titles matching `<pattern>` are grouping epics only — no management
+needed. Exclude from duplicate candidates, sync, triage, and reports.
+
+## Shared board option labels (copy-paste contract)
+
+Keep staging select options byte-identical to the shared board's. List
+each select property and its exact labels here, including any typos the
+shared board actually uses.
+
+- Type / Status / Priority / Estimated workload / Confidence / Section /
+  Project: `<labels>`
+
+Record extra tracker workflow states and their transition ids here too,
+plus how cancelled or merged-away tickets map onto staging statuses.
+
+## First-run setup
+
+1. Register the Atlassian MCP server as `atlassian-http`.
+2. With the personal workspace connected, present the planned database
+   name, location, and property list; on approval, create the
+   "Ticket Staging" database from the schema summary in SKILL.md plus the
+   labels above.
+3. Offer to import the newest snapshot CSV as staging rows: properties
+   only, no body blocks, `Sync State` = Copied, `Shared Board URL` = the
+   row's url. Do NOT create tracker issues for imports; link lazily when
+   work on one actually starts.
+4. Record the staging data source ID in `reference.md`.
+
+## Snapshot refresh query
+
+When the shared workspace is connected, run via notion-query-data-sources
+(SQL mode) and save the result to
+`~/.claude/ticket/shared-board-snapshot-<YYYY-MM-DD>.csv`:
+
+```sql
+SELECT id, url, Title, Type, Status, Priority, Project, Section, Confidence,
+       "Estimated workload", "date:Deadline:start", "Last edited time"
+FROM "collection://<shared board uuid>"
+WHERE Engineers LIKE '%<user id prefix>%'
+  AND Status IN (<open status labels>)
+ORDER BY "Last edited time" DESC
+```
+
+## Jira search example
+
+```
+project = <KEY> AND text ~ "<keywords>" ORDER BY updated DESC
+```

--- a/symlink-manifest.sh
+++ b/symlink-manifest.sh
@@ -42,6 +42,8 @@ MANIFEST_CLAUDE_FILES=(
   skills/delivery-workflow/SKILL.md
   skills/expand-tool-output/SKILL.md
   skills/prepare-compaction/SKILL.md
+  skills/ticket/SKILL.md
+  skills/ticket/reference.md
   rules/golang/coding-style.md
   rules/golang/hooks.md
   rules/golang/patterns.md

--- a/symlink-manifest.sh
+++ b/symlink-manifest.sh
@@ -43,7 +43,6 @@ MANIFEST_CLAUDE_FILES=(
   skills/expand-tool-output/SKILL.md
   skills/prepare-compaction/SKILL.md
   skills/ticket/SKILL.md
-  skills/ticket/reference.md
   rules/golang/coding-style.md
   rules/golang/hooks.md
   rules/golang/patterns.md


### PR DESCRIPTION
## 概要

Jira のチームプロジェクトと個人用 Notion staging ボードの間でチケットを作成・同期する `ticket` skill を追跡対象に加える。

## これまで untracked だった理由と今回の対応

skill 本体に社内固有の識別子が埋め込まれており、このリポジトリは public のためローカル限定にしていた。今回はファイルを分割して公開できる形にする。

- `SKILL.md`(追跡対象): ワークフローのみ。entry point、create/sync の手順、status-change プロンプト、staging スキーマの構成、hard rules。
- `reference.md`(machine-local): 具体値のみ。Jira のプロジェクトとボード URL、Notion のデータソース ID とワークスペース ID、共有ボードの選択肢ラベル、紐付け専用 Epic のタイトルパターン、スナップショット取得用クエリ。gitignore 対象で、symlink manifest にも載せない。
- `reference.example.md`(追跡対象): 上記の雛形。新しい環境ではこれを複製して値を埋める。

`SKILL.md` は実行開始時に `reference.md` を読む。手元での挙動は変わらないまま、社内固有の情報は公開されない。

## 変更点

- `claude/skills/ticket/SKILL.md` — サニタイズ済みの skill 本体(新規)
- `claude/skills/ticket/reference.example.md` — 具体値の雛形(新規)
- `claude/.gitignore` — `skills/ticket/` を whitelist に追加し、`reference.md` は ignore
- `symlink-manifest.sh` — `SKILL.md` のみ `~/.claude/` へ symlink

`reference.md` を manifest に載せない理由は、install テストが manifest の全エントリを symlink として検証するため。追跡されないファイルは新規 clone に存在せず、この検証を通せない。

## 確認したこと

- CI 3ジョブ(lint / validate-configs / install-ubuntu)が pass
- `git check-ignore` で `reference.md` が ignore され、`SKILL.md` が追跡対象になることを確認
- 追跡対象の差分に対してサイトホスト名、プロジェクトキー、組織名、`collection://` ID、UUID、Epic パターンを走査し、ヒットなし