### PR TITLE
refactor: compaction telemetryを稼働確認へ絞る

### DIFF
--- a/.shell-utils/dotfiles-doctor.sh
+++ b/.shell-utils/dotfiles-doctor.sh
@@ -71,9 +71,9 @@ compactor_hook_configured() {
   grep -Fq 'compact-tool-output.py' "$HOME/.claude/settings.json" 2> /dev/null
 }
 
-run_compactor_stats() {
+run_compactor_health() {
   python3 "$DOTFILES_DIR/claude/hooks/compact-tool-output.py" \
-    stats --days "$HARNESS_WINDOW_DAYS"
+    health --days "$HARNESS_WINDOW_DAYS"
 }
 
 check_headroom() {
@@ -189,7 +189,7 @@ check_claude_version() {
 check_tool_output_compaction() {
   echo "== Claude tool-output compaction (last ${HARNESS_WINDOW_DAYS} days) =="
   local before=$WARNINGS
-  local stats active last_invoked failures archives saved
+  local health active last_invoked last_error
   local script="$DOTFILES_DIR/claude/hooks/compact-tool-output.py"
 
   if [ ! -f "$script" ]; then
@@ -198,39 +198,28 @@ check_tool_output_compaction() {
     warn "Compaction hook is not configured in Claude settings; next: rerun install.sh"
   elif ! has_command python3; then
     warn "python3 is unavailable, so compaction health cannot be checked; next: rerun install.sh"
-  elif stats=$(run_compactor_stats 2>&1); then
-    active=$(stats_value "hook active" "$stats")
-    last_invoked=$(stats_value "hook last invoked" "$stats")
-    failures=$(stats_value "hook failures" "$stats")
-    archives=$(stats_value "archives" "$stats")
-    saved=$(stats_value "saved" "$stats")
+  elif health=$(run_compactor_health 2>&1); then
+    active=$(stats_value "hook active" "$health")
+    last_invoked=$(stats_value "hook last invoked" "$health")
+    last_error=$(stats_value "hook last error" "$health")
 
     if [ "$active" = "yes" ]; then
       info "hook active; last invoked ${last_invoked:-unknown}"
-      if [ "$archives" = "0" ]; then
-        info "0 compactions is healthy: no supported output crossed the threshold"
-      fi
     else
-      warn "Compaction hook was not observed in ${HARNESS_WINDOW_DAYS} days; next: use a Read/Grep/Glob/Web/MCP tool, then rerun compact-tool-output.py stats"
+      warn "Compaction hook was not observed in ${HARNESS_WINDOW_DAYS} days; next: use a Read/Grep/Glob/Web/MCP tool, then run python3 ~/.claude/hooks/compact-tool-output.py health"
     fi
 
-    case "$failures" in
-      '' | *[!0-9]*)
-        warn "Compaction failure count could not be parsed; next: rerun compact-tool-output.py stats"
+    case "$last_error" in
+      none) ;;
+      '')
+        warn "Compaction error state could not be parsed; next: run python3 ~/.claude/hooks/compact-tool-output.py health"
         ;;
-      0) ;;
       *)
-        warn "$failures compaction hook failure(s) in ${HARNESS_WINDOW_DAYS} days; next: inspect Claude hook stderr and run the hook tests"
+        warn "Compaction hook has an unresolved $last_error; next: run the hook tests, then use a supported tool once"
         ;;
     esac
-
-    if [[ "$archives" =~ ^[0-9]+$ && -n "$saved" ]]; then
-      info "${archives} compaction(s), saved $saved"
-    else
-      warn "Compaction savings could not be parsed; next: rerun compact-tool-output.py stats"
-    fi
   else
-    warn "Compaction stats failed; next: run python3 ~/.claude/hooks/compact-tool-output.py stats"
+    warn "Compaction health check failed; next: run python3 ~/.claude/hooks/compact-tool-output.py health"
   fi
   section_ok "$before"
 }

--- a/README.md
+++ b/README.md
@@ -97,15 +97,15 @@ Large Read, Grep, Glob, Web, and MCP results are shortened before entering the
 conversation. The full result is retained locally for seven days with user-only
 permissions and can be queried through the `expand-tool-output` skill.
 
-Show health and savings for the last seven days:
+Show savings from the retained archives when deciding whether the hook is useful:
 
 ```bash
 python3 ~/.claude/hooks/compact-tool-output.py stats
 ```
 
-The report distinguishes an active hook with zero threshold crossings from a
-hook that has not run, and counts fail-open hook errors without storing error
-messages or tool payloads.
+The weekly doctor checks only the last hook invocation and one unresolved error.
+It does not aggregate compaction counts or savings. Error records contain the
+exception type and time, never tool payloads or exception messages.
 
 ## Claude Bash Sandbox Canary
 

--- a/claude/hooks/compact-tool-output.py
+++ b/claude/hooks/compact-tool-output.py
@@ -28,7 +28,8 @@ DEFAULT_PREVIEW_CHARS = 12_000
 DEFAULT_RETENTION_DAYS = 7
 DEFAULT_HEALTH_TOUCH_SECONDS = 300
 LAST_INVOKED_FILE = ".last-invoked"
-ERROR_DIR = ".errors"
+LAST_ERROR_FILE = ".last-error"
+LEGACY_ERROR_DIR = ".errors"
 
 
 def env_int(name: str, default: int, minimum: int) -> int:
@@ -205,6 +206,26 @@ def prepare_cache(root: Path) -> None:
 def mark_hook_invoked(root: Path) -> None:
     """Record supported hook traffic without retaining tool input or output."""
     prepare_cache(root)
+    error_marker = root / LAST_ERROR_FILE
+    try:
+        if error_marker.is_file() and not error_marker.is_symlink():
+            error_marker.unlink()
+    except OSError:
+        pass
+
+    legacy_errors = root / LEGACY_ERROR_DIR
+    if legacy_errors.is_dir() and not legacy_errors.is_symlink():
+        for path in legacy_errors.glob("*.json"):
+            try:
+                if path.is_file() and not path.is_symlink():
+                    path.unlink()
+            except OSError:
+                continue
+        try:
+            legacy_errors.rmdir()
+        except OSError:
+            pass
+
     marker = root / LAST_INVOKED_FILE
     interval = env_int(
         "CLAUDE_TOOL_OUTPUT_HEALTH_TOUCH_SECONDS",
@@ -231,36 +252,17 @@ def mark_hook_invoked(root: Path) -> None:
         "CLAUDE_TOOL_OUTPUT_RETENTION_DAYS", DEFAULT_RETENTION_DAYS, 1
     )
     clean_expired_archives(root, retention_days)
-    clean_expired_errors(root, retention_days)
-
-
-def clean_expired_errors(root: Path, retention_days: int) -> None:
-    errors = root / ERROR_DIR
-    if not errors.is_dir() or errors.is_symlink():
-        return
-    cutoff = time.time() - retention_days * 86_400
-    for path in errors.glob("*.json"):
-        try:
-            if path.is_file() and not path.is_symlink() and path.stat().st_mtime < cutoff:
-                path.unlink()
-        except OSError:
-            continue
 
 
 def record_hook_error(root: Path, error: Exception) -> None:
     """Record only failure metadata; exception text may contain sensitive data."""
     prepare_cache(root)
-    errors = root / ERROR_DIR
-    prepare_cache(errors)
-    retention_days = env_int(
-        "CLAUDE_TOOL_OUTPUT_RETENTION_DAYS", DEFAULT_RETENTION_DAYS, 1
-    )
-    clean_expired_errors(root, retention_days)
-    path = errors / f"{time.time_ns()}-{os.getpid()}.json"
+    path = root / LAST_ERROR_FILE
+    temporary = root / f"{LAST_ERROR_FILE}-{os.getpid()}-{time.time_ns()}.tmp"
     flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
     if hasattr(os, "O_NOFOLLOW"):
         flags |= os.O_NOFOLLOW
-    descriptor = os.open(path, flags, 0o600)
+    descriptor = os.open(temporary, flags, 0o600)
     with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
         json.dump(
             {
@@ -271,6 +273,8 @@ def record_hook_error(root: Path, error: Exception) -> None:
             stream,
         )
         stream.write("\n")
+    os.replace(temporary, path)
+    os.chmod(path, 0o600)
 
 
 def clean_expired_archives(root: Path, retention_days: int) -> None:
@@ -428,23 +432,34 @@ def expand_archive(args: argparse.Namespace) -> int:
     return 0
 
 
-def show_stats(days: int) -> int:
+def show_stats() -> int:
     root = cache_dir()
-    days = max(days, 1)
-    cutoff = time.time() - days * 86_400
     archives: list[dict[str, Any]] = []
     if root.exists():
         for path in root.glob("*.json"):
             if path.is_symlink():
                 continue
             try:
-                if path.stat().st_mtime < cutoff:
-                    continue
                 with path.open(encoding="utf-8") as stream:
                     archives.append(json.load(stream))
             except (OSError, json.JSONDecodeError):
                 continue
 
+    original = sum(int(item.get("original_chars", 0)) for item in archives)
+    compacted = sum(int(item.get("compacted_chars", 0)) for item in archives)
+    saved = max(original - compacted, 0)
+    percent = saved * 100 / original if original else 0
+    print(f"archives: {len(archives)}")
+    print(f"original chars: {original:,}")
+    print(f"compacted chars: {compacted:,}")
+    print(f"saved: {saved:,} chars ({percent:.1f}%, about {saved // 4:,} tokens)")
+    return 0
+
+
+def show_health(days: int) -> int:
+    root = cache_dir()
+    days = max(days, 1)
+    cutoff = time.time() - days * 86_400
     last_invoked: float | None = None
     marker = root / LAST_INVOKED_FILE
     try:
@@ -454,34 +469,39 @@ def show_stats(days: int) -> int:
     except OSError:
         pass
 
-    failures = 0
-    errors = root / ERROR_DIR
-    if errors.is_dir() and not errors.is_symlink():
-        for path in errors.glob("*.json"):
-            try:
-                if path.is_file() and not path.is_symlink() and path.stat().st_mtime >= cutoff:
-                    failures += 1
-            except OSError:
-                continue
-
-    original = sum(int(item.get("original_chars", 0)) for item in archives)
-    compacted = sum(int(item.get("compacted_chars", 0)) for item in archives)
-    saved = max(original - compacted, 0)
-    percent = saved * 100 / original if original else 0
     active = last_invoked is not None and last_invoked >= cutoff
     last_invoked_text = (
         datetime.fromtimestamp(last_invoked, UTC).isoformat().replace("+00:00", "Z")
         if last_invoked is not None
         else "never"
     )
+    last_error = "none"
+    error_marker = root / LAST_ERROR_FILE
+    try:
+        if error_marker.is_file() and not error_marker.is_symlink():
+            with error_marker.open(encoding="utf-8") as stream:
+                error_record = json.load(stream)
+            last_error = (
+                f"{error_record['error_type']} at {error_record['created_at']}"
+            )
+    except (OSError, KeyError, json.JSONDecodeError):
+        last_error = "unreadable"
+
+    if last_error == "none":
+        legacy_errors = root / LEGACY_ERROR_DIR
+        try:
+            if legacy_errors.is_dir() and not legacy_errors.is_symlink() and any(
+                path.is_file() and not path.is_symlink()
+                for path in legacy_errors.glob("*.json")
+            ):
+                last_error = "legacy records pending migration"
+        except OSError:
+            last_error = "unreadable"
+
     print(f"window: {days} days")
     print(f"hook active: {'yes' if active else 'no'}")
     print(f"hook last invoked: {last_invoked_text}")
-    print(f"hook failures: {failures}")
-    print(f"archives: {len(archives)}")
-    print(f"original chars: {original:,}")
-    print(f"compacted chars: {compacted:,}")
-    print(f"saved: {saved:,} chars ({percent:.1f}%, about {saved // 4:,} tokens)")
+    print(f"hook last error: {last_error}")
     return 0
 
 
@@ -494,8 +514,9 @@ def parse_args() -> argparse.Namespace:
     expand.add_argument("--context", type=int, default=2)
     expand.add_argument("--head", type=int, default=0)
     expand.add_argument("--tail", type=int, default=0)
-    stats_parser = subparsers.add_parser("stats", help="show local compaction savings")
-    stats_parser.add_argument("--days", type=int, default=DEFAULT_RETENTION_DAYS)
+    subparsers.add_parser("stats", help="show savings from retained archives")
+    health_parser = subparsers.add_parser("health", help="show hook health")
+    health_parser.add_argument("--days", type=int, default=DEFAULT_RETENTION_DAYS)
     return parser.parse_args()
 
 
@@ -504,7 +525,9 @@ def main() -> int:
     if args.command == "expand":
         return expand_archive(args)
     if args.command == "stats":
-        return show_stats(args.days)
+        return show_stats()
+    if args.command == "health":
+        return show_health(args.days)
     return run_hook()
 
 

--- a/claude/hooks/tests/test_compact_tool_output.py
+++ b/claude/hooks/tests/test_compact_tool_output.py
@@ -6,7 +6,6 @@ import stat
 import subprocess
 import sys
 import tempfile
-import time
 import unittest
 
 
@@ -202,13 +201,12 @@ class CompactToolOutputTest(unittest.TestCase):
         )
 
         self.assertEqual(stats_result.returncode, 0, stats_result.stderr)
-        self.assertIn("window: 7 days", stats_result.stdout)
-        self.assertIn("hook active: yes", stats_result.stdout)
-        self.assertIn("hook failures: 0", stats_result.stdout)
         self.assertIn("archives: 1", stats_result.stdout)
         self.assertRegex(stats_result.stdout, r"saved: [1-9][0-9,]* chars")
+        self.assertNotIn("hook active", stats_result.stdout)
+        self.assertNotIn("hook failures", stats_result.stdout)
 
-    def test_stats_distinguishes_active_hook_with_no_compactions(self) -> None:
+    def test_health_reports_recent_hook_without_compactions(self) -> None:
         hook_result = self.run_hook(
             {
                 "session_id": "session-6",
@@ -219,19 +217,19 @@ class CompactToolOutputTest(unittest.TestCase):
         )
         self.assertEqual(hook_result.returncode, 0, hook_result.stderr)
 
-        stats_result = subprocess.run(
-            [sys.executable, str(SCRIPT), "stats", "--days", "7"],
+        health_result = subprocess.run(
+            [sys.executable, str(SCRIPT), "health", "--days", "7"],
             text=True,
             capture_output=True,
             env=self.env,
             check=False,
         )
 
-        self.assertEqual(stats_result.returncode, 0, stats_result.stderr)
-        self.assertIn("hook active: yes", stats_result.stdout)
-        self.assertNotIn("hook last invoked: never", stats_result.stdout)
-        self.assertIn("hook failures: 0", stats_result.stdout)
-        self.assertIn("archives: 0", stats_result.stdout)
+        self.assertEqual(health_result.returncode, 0, health_result.stderr)
+        self.assertIn("hook active: yes", health_result.stdout)
+        self.assertNotIn("hook last invoked: never", health_result.stdout)
+        self.assertIn("hook last error: none", health_result.stdout)
+        self.assertNotIn("archives", health_result.stdout)
 
     def test_records_failure_metadata_without_payload_content(self) -> None:
         secret = "credential-do-not-log"
@@ -239,52 +237,107 @@ class CompactToolOutputTest(unittest.TestCase):
 
         self.assertEqual(result.returncode, 0)
         self.assertNotIn(secret, result.stderr)
-        error_files = list((self.cache_dir / ".errors").glob("*.json"))
-        self.assertEqual(len(error_files), 1)
-        error_record = json.loads(error_files[0].read_text())
+        error_file = self.cache_dir / ".last-error"
+        self.assertTrue(error_file.is_file())
+        error_record = json.loads(error_file.read_text())
         self.assertEqual(error_record["error_type"], "JSONDecodeError")
         self.assertNotIn(secret, json.dumps(error_record))
 
-        stats_result = subprocess.run(
-            [sys.executable, str(SCRIPT), "stats"],
+        health_result = subprocess.run(
+            [sys.executable, str(SCRIPT), "health"],
             text=True,
             capture_output=True,
             env=self.env,
             check=False,
         )
-        self.assertIn("hook active: no", stats_result.stdout)
-        self.assertIn("hook failures: 1", stats_result.stdout)
+        self.assertIn("hook active: no", health_result.stdout)
+        self.assertIn("hook last error: JSONDecodeError at ", health_result.stdout)
 
-    def test_stats_excludes_archives_and_failures_older_than_window(self) -> None:
         hook_result = self.run_hook(
             {
                 "session_id": "session-7",
                 "tool_use_id": "tool-8",
-                "tool_name": "Glob",
-                "tool_response": {"filenames": "old.txt\n" * 500},
+                "tool_name": "Read",
+                "tool_response": {"content": "small"},
             }
         )
         self.assertEqual(hook_result.returncode, 0, hook_result.stderr)
-        error_result = self.run_raw_hook("{old-invalid-json")
-        self.assertEqual(error_result.returncode, 0)
+        self.assertFalse((self.cache_dir / ".last-error").exists())
 
-        old_timestamp = time.time() - 8 * 86_400
-        archive_path = next(self.cache_dir.glob("*.json"))
-        error_path = next((self.cache_dir / ".errors").glob("*.json"))
-        os.utime(archive_path, (old_timestamp, old_timestamp))
-        os.utime(error_path, (old_timestamp, old_timestamp))
-
-        stats_result = subprocess.run(
-            [sys.executable, str(SCRIPT), "stats", "--days", "7"],
+        health_result = subprocess.run(
+            [sys.executable, str(SCRIPT), "health"],
             text=True,
             capture_output=True,
             env=self.env,
             check=False,
         )
-        self.assertEqual(stats_result.returncode, 0, stats_result.stderr)
-        self.assertIn("hook active: yes", stats_result.stdout)
-        self.assertIn("hook failures: 0", stats_result.stdout)
-        self.assertIn("archives: 0", stats_result.stdout)
+        self.assertEqual(health_result.returncode, 0, health_result.stderr)
+        self.assertIn("hook active: yes", health_result.stdout)
+        self.assertIn("hook last error: none", health_result.stdout)
+
+    def test_health_marks_old_invocation_inactive(self) -> None:
+        hook_result = self.run_hook(
+            {
+                "session_id": "session-8",
+                "tool_use_id": "tool-9",
+                "tool_name": "Read",
+                "tool_response": {"content": "small"},
+            }
+        )
+        self.assertEqual(hook_result.returncode, 0, hook_result.stderr)
+        marker = self.cache_dir / ".last-invoked"
+        os.utime(marker, (0, 0))
+
+        health_result = subprocess.run(
+            [sys.executable, str(SCRIPT), "health", "--days", "7"],
+            text=True,
+            capture_output=True,
+            env=self.env,
+            check=False,
+        )
+
+        self.assertEqual(health_result.returncode, 0, health_result.stderr)
+        self.assertIn("hook active: no", health_result.stdout)
+
+    def test_health_reports_and_clears_legacy_error_records(self) -> None:
+        legacy_errors = self.cache_dir / ".errors"
+        legacy_errors.mkdir(parents=True)
+        (legacy_errors / "old.json").write_text(
+            json.dumps({"error_type": "ValueError"}), encoding="utf-8"
+        )
+
+        health_result = subprocess.run(
+            [sys.executable, str(SCRIPT), "health"],
+            text=True,
+            capture_output=True,
+            env=self.env,
+            check=False,
+        )
+        self.assertEqual(health_result.returncode, 0, health_result.stderr)
+        self.assertIn(
+            "hook last error: legacy records pending migration",
+            health_result.stdout,
+        )
+
+        hook_result = self.run_hook(
+            {
+                "session_id": "session-9",
+                "tool_use_id": "tool-10",
+                "tool_name": "Read",
+                "tool_response": {"content": "small"},
+            }
+        )
+        self.assertEqual(hook_result.returncode, 0, hook_result.stderr)
+        self.assertFalse(legacy_errors.exists())
+
+        health_result = subprocess.run(
+            [sys.executable, str(SCRIPT), "health"],
+            text=True,
+            capture_output=True,
+            env=self.env,
+            check=False,
+        )
+        self.assertIn("hook last error: none", health_result.stdout)
 
     def test_expand_rejects_an_invalid_archive_id(self) -> None:
         result = subprocess.run(

--- a/test/test-dotfiles-doctor.sh
+++ b/test/test-dotfiles-doctor.sh
@@ -58,14 +58,12 @@ run_claude_latest_version() {
   printf '2.1.241\n'
 }
 
-run_compactor_stats() {
+run_compactor_health() {
   printf '%s\n' \
     'window: 7 days' \
     'hook active: yes' \
     'hook last invoked: 2026-08-26T00:00:00Z' \
-    'hook failures: 0' \
-    'archives: 0' \
-    'saved: 0 chars (0.0%, about 0 tokens)'
+    'hook last error: none'
 }
 
 healthy_output="$TEST_OUTPUT_DIR/healthy"
@@ -74,7 +72,7 @@ check_agent_harness > "$healthy_output"
 [ "$WARNINGS" -eq 0 ] || fail "healthy harness produced $WARNINGS warning(s)"
 assert_contains "2 MCP server(s) connected" "$healthy_output"
 assert_contains "installed 2.1.241; latest stable 2.1.241" "$healthy_output"
-assert_contains "0 compactions is healthy" "$healthy_output"
+assert_contains "hook active; last invoked 2026-08-26T00:00:00Z" "$healthy_output"
 
 run_headroom_status() {
   printf 'Status: stopped\nHealthy: yes\n'
@@ -101,14 +99,12 @@ run_claude_version() {
   printf '2.1.231 (Claude Code)\n'
 }
 
-run_compactor_stats() {
+run_compactor_health() {
   printf '%s\n' \
     'window: 7 days' \
     'hook active: no' \
     'hook last invoked: never' \
-    'hook failures: 1' \
-    'archives: 0' \
-    'saved: 0 chars (0.0%, about 0 tokens)'
+    'hook last error: JSONDecodeError at 2026-08-26T00:00:00Z'
 }
 
 unhealthy_output="$TEST_OUTPUT_DIR/unhealthy"
@@ -119,7 +115,7 @@ assert_contains "run install.sh --headroom-only" "$unhealthy_output"
 assert_contains "MCP server 'serena' is not connected" "$unhealthy_output"
 assert_contains "Claude Code installed 2.1.231; latest stable 2.1.241" "$unhealthy_output"
 assert_contains "Compaction hook was not observed in 7 days" "$unhealthy_output"
-assert_contains "1 compaction hook failure(s) in 7 days" "$unhealthy_output"
+assert_contains "unresolved JSONDecodeError" "$unhealthy_output"
 assert_not_contains "credential-do-not-log" "$unhealthy_output"
 
 printf 'dotfiles-doctor tests: ok\n'


### PR DESCRIPTION
## 概要

PR #41 で追加した tool-output compaction の計測を整理します。削除するのではなく、日常の判断に必要な情報へ絞ります。

狙いは単純です。

実キャッシュには17件のアーカイブが残っています。元の1,405,360文字は204,068文字まで縮小されていました。削減量は約1,201,292文字、概算で約30万トークンです。効果は十分です。この確認手段は `stats` に残し、週次doctorからは圧縮件数・削減量・期間内エラー件数の集計を外します。

## 変更内容

- `stats` は、保持中アーカイブの圧縮効果だけをオンデマンドで表示
- `health --days N` を追加し、最終実行時刻と未解決エラーだけを表示
- hookエラーの記録をイベントごとのファイル群から `.last-error` 1件へ変更
- 旧 `.errors` が残っていれば `health` で知らせ、次の対応対象ツール実行時に削除
- エラーには例外型と発生時刻だけを保存し、payloadや例外メッセージは保存しない
- 次の対応対象ツール実行時に未解決エラーを消し、その実行も失敗した場合は新しいエラーで更新
- `dotfiles-doctor.sh` は `health` の結果だけを確認し、具体的な復旧手順を案内
- READMEと回帰テストを新しい責務分担に合わせて更新

## やりすぎを戻した点

- doctor実行のたびに圧縮効果を集計しない
- 期間内の失敗回数を追跡しない
- エラーごとのファイルを蓄積しない

圧縮効果を見直したいときだけ、次を実行します。

```bash
python3 ~/.claude/hooks/compact-tool-output.py stats
```

## 検証

- compactor unit tests: 17件成功
- dotfiles doctor tests: 成功
- Claude sandbox tests: 成功
- ShellCheck: 警告なし
- `git diff --check`: 問題なし
- 実キャッシュに対する `stats` / `health` の読み取り確認

## 適用時の注意

現在のローカル `~/.claude` は、未コミット変更を含むdotfiles本体の古いブランチを参照しています。その作業を壊さないため、自動では切り替えません。このPRのマージ後にdotfiles本体を安全に更新し、`health` の最終実行マーカーを確認します。

Refs #33
