### PR TITLE
feat(doctor): report whether output-shaper savings are measured

### DIFF
--- a/.shell-utils/dotfiles-doctor.sh
+++ b/.shell-utils/dotfiles-doctor.sh
@@ -79,7 +79,7 @@ run_compactor_health() {
 check_headroom() {
   echo "== Headroom proxy =="
   local before=$WARNINGS
-  local output status healthy savings requests saved reduction
+  local output status healthy savings method requests saved reduction
 
   if ! has_command headroom; then
     warn "Headroom is not installed; next: rerun install.sh"
@@ -106,11 +106,12 @@ check_headroom() {
       if [[ "$savings" == *"No shaped requests recorded yet."* ]]; then
         info "output shaper: 0 shaped requests recorded"
       else
+        method=$(printf '%s\n' "$savings" | sed -n 's/^[[:space:]]*Method:[[:space:]]*\([A-Z][A-Z]*\).*/\1/p' | head -n 1)
         requests=$(printf '%s\n' "$savings" | sed -n 's/^[[:space:]]*Requests:[[:space:]]*//p' | head -n 1)
         saved=$(printf '%s\n' "$savings" | sed -n 's/^[[:space:]]*Saved:[[:space:]]*//p' | head -n 1)
         reduction=$(printf '%s\n' "$savings" | sed -n 's/^[[:space:]]*Reduction:[[:space:]]*//p' | head -n 1)
         if [ -n "$requests" ]; then
-          info "output shaper: $requests; ${saved:-saved amount unavailable}; ${reduction:-reduction unavailable}"
+          info "output shaper: ${method:+$method; }$requests; ${saved:-saved amount unavailable}; ${reduction:-reduction unavailable}"
         else
           info "output shaper: data exists; next: run headroom output-savings for details"
         fi

--- a/README.md
+++ b/README.md
@@ -135,6 +135,11 @@ Claude proxy on port 8787. It uses Docker when available and a native scheduled
 task otherwise. The beta output shaper is enabled and Claude Code is routed
 through the proxy from new shell sessions.
 
+A 10% holdout stays unshaped, so `headroom output-savings` reports
+`Method: MEASURED` against a real control arm instead of an estimate against
+a synthetic baseline. `dotfiles-doctor.sh` prints that method alongside the
+reduction so an estimated number is never read as a measured one.
+
 Learn the preferred response length again after enough Claude history has
 accumulated:
 

--- a/README.md
+++ b/README.md
@@ -135,10 +135,11 @@ Claude proxy on port 8787. It uses Docker when available and a native scheduled
 task otherwise. The beta output shaper is enabled and Claude Code is routed
 through the proxy from new shell sessions.
 
-A 10% holdout stays unshaped, so `headroom output-savings` reports
-`Method: MEASURED` against a real control arm instead of an estimate against
-a synthetic baseline. `dotfiles-doctor.sh` prints that method alongside the
-reduction so an estimated number is never read as a measured one.
+`dotfiles-doctor.sh` prints the reported measurement method next to the
+reduction. `ESTIMATED` compares shaped output against a synthetic baseline
+and can report a confidence band wider than the reduction itself, so it is
+not a basis for deciding whether the proxy earns its place. `MEASURED`
+requires an unshaped control arm via `HEADROOM_OUTPUT_HOLDOUT`.
 
 Learn the preferred response length again after enough Claude history has
 accumulated:

--- a/install.sh
+++ b/install.sh
@@ -359,7 +359,6 @@ setup_cli_tools() {
 # ========================================
 # Recreates the user-scoped deployment when missing or when the persisted
 # output-shaper settings drift. Prefer Docker and fall back to a native task.
-# A 10% holdout stays unshaped so savings are measured, not estimated.
 
 setup_headroom() {
   if ! command -v headroom > /dev/null 2>&1; then
@@ -384,8 +383,7 @@ setup_headroom() {
        and .preset == $preset
        and .runtime_kind == $runtime
        and .base_env.HEADROOM_ROLLOUT_CHANNEL == "beta"
-       and .base_env.HEADROOM_OUTPUT_SHAPER == "1"
-       and .base_env.HEADROOM_OUTPUT_HOLDOUT == "0.1"' \
+       and .base_env.HEADROOM_OUTPUT_SHAPER == "1"' \
       "$manifest" > /dev/null 2>&1; then
     echo "  exists: Headroom persistent Claude deployment ($preset)"
     if ! headroom install status --profile default 2>/dev/null | grep -q '^Status:.*running'; then
@@ -420,7 +418,6 @@ setup_headroom() {
     --no-telemetry \
     --env HEADROOM_ROLLOUT_CHANNEL=beta \
     --env HEADROOM_OUTPUT_SHAPER=1 \
-    --env HEADROOM_OUTPUT_HOLDOUT=0.1 \
     || echo "  failed: Headroom persistent Claude deployment"
 }
 

--- a/install.sh
+++ b/install.sh
@@ -359,6 +359,7 @@ setup_cli_tools() {
 # ========================================
 # Recreates the user-scoped deployment when missing or when the persisted
 # output-shaper settings drift. Prefer Docker and fall back to a native task.
+# A 10% holdout stays unshaped so savings are measured, not estimated.
 
 setup_headroom() {
   if ! command -v headroom > /dev/null 2>&1; then
@@ -383,7 +384,8 @@ setup_headroom() {
        and .preset == $preset
        and .runtime_kind == $runtime
        and .base_env.HEADROOM_ROLLOUT_CHANNEL == "beta"
-       and .base_env.HEADROOM_OUTPUT_SHAPER == "1"' \
+       and .base_env.HEADROOM_OUTPUT_SHAPER == "1"
+       and .base_env.HEADROOM_OUTPUT_HOLDOUT == "0.1"' \
       "$manifest" > /dev/null 2>&1; then
     echo "  exists: Headroom persistent Claude deployment ($preset)"
     if ! headroom install status --profile default 2>/dev/null | grep -q '^Status:.*running'; then
@@ -418,6 +420,7 @@ setup_headroom() {
     --no-telemetry \
     --env HEADROOM_ROLLOUT_CHANNEL=beta \
     --env HEADROOM_OUTPUT_SHAPER=1 \
+    --env HEADROOM_OUTPUT_HOLDOUT=0.1 \
     || echo "  failed: Headroom persistent Claude deployment"
 }
 

--- a/test/test-dotfiles-doctor.sh
+++ b/test/test-dotfiles-doctor.sh
@@ -74,6 +74,38 @@ assert_contains "2 MCP server(s) connected" "$healthy_output"
 assert_contains "installed 2.1.241; latest stable 2.1.241" "$healthy_output"
 assert_contains "hook active; last invoked 2026-08-26T00:00:00Z" "$healthy_output"
 
+run_headroom_savings() {
+  printf '%s\n' \
+    '  Method:    ESTIMATED (synthetic control)' \
+    '  Requests:  1,950 shaped' \
+    '  Saved:     1,402,159 output tokens' \
+    '  Reduction: 63.5%   (95% CI 12.9% … 114.2%)'
+}
+
+estimated_output="$TEST_OUTPUT_DIR/estimated-savings"
+WARNINGS=0
+check_headroom > "$estimated_output"
+[ "$WARNINGS" -eq 0 ] || fail "estimated savings produced $WARNINGS warning(s)"
+assert_contains "output shaper: ESTIMATED; 1,950 shaped; 1,402,159 output tokens; 63.5%" "$estimated_output"
+
+run_headroom_savings() {
+  printf '%s\n' \
+    '  Method:    MEASURED' \
+    '  Requests:  1,950 shaped' \
+    '  Saved:     1,402,159 output tokens' \
+    '  Reduction: 63.5%'
+}
+
+measured_output="$TEST_OUTPUT_DIR/measured-savings"
+WARNINGS=0
+check_headroom > "$measured_output"
+[ "$WARNINGS" -eq 0 ] || fail "measured savings produced $WARNINGS warning(s)"
+assert_contains "output shaper: MEASURED; 1,950 shaped" "$measured_output"
+
+run_headroom_savings() {
+  printf 'No shaped requests recorded yet.\n'
+}
+
 run_headroom_status() {
   printf 'Status: stopped\nHealthy: yes\n'
 }


### PR DESCRIPTION
Parent: #33 (Phase 0, "Headroomとtool-output compactorの効果を確認し、効果の薄い常駐経路を外す")

## 背景

epic #33 は「効果の薄い常駐経路を外す」ことを想定していたが、実測すると前提が変わっていた。

**tool-output compactor**: 直近24時間で25 archive、1,846,702 → 300,100 文字の **実測 83.7% 削減**。archive の `original_chars` / `compacted_chars` を直接集計した値なので推定を含まない。外す理由はない。

**Headroom output shaper**: 稼働中で 1,950 shaped、63.5% 削減。ただし `headroom output-savings` の出力は次の通り。

```
Method:    ESTIMATED (synthetic control)
Reduction: 63.5%   (95% CI 12.9% … 114.2%)
```

CI 上限が 100% を超えており、削減率の推定として成立していない。それにもかかわらず doctor の行は、実測値とまったく同じ見た目で 63.5% を表示していた。

## 変更

- `.shell-utils/dotfiles-doctor.sh`: `Method:` を parse し、`output shaper: ESTIMATED; 1,950 shaped; ...` の形で削減率の前に表示する。推定値を実測値として読まないようにするため
- `test/test-dotfiles-doctor.sh`: ESTIMATED と MEASURED の両方の fixture を追加。従来は "No shaped requests recorded yet." のケースしかテストしていなかった
- `README.md`: 2つの method の違いと、ESTIMATED が存廃判断の根拠にならないことを記載

warning は増やしていない。method は info として出すだけ。

## holdout を入れなかった理由

当初は `install.sh` の deployment に `HEADROOM_OUTPUT_HOLDOUT=0.1` を追加して MEASURED にする変更を含めていたが、レビューで機能しないことが分かったため落とした（2つ目のコミット）。

`install.sh` は `--env HEADROOM_ROLLOUT_CHANNEL=beta --env HEADROOM_OUTPUT_SHAPER=1` を渡しているが、この値は実環境のどこにも存在しない。

- `manifest.json` の `base_env`: PORT / HOST / MODE / BACKEND / TELEMETRY のみ
- 稼働中の container (`docker inspect headroom-default`): 同上
- `~/.headroom/deploy/default/run-headroom.sh`: 同上

同じ方法で `HEADROOM_OUTPUT_HOLDOUT` を渡しても MEASURED にはならず、決して一致しない drift 条件を1つ増やすだけだった。

この過程で `setup_headroom` の drift 検知が実環境と乖離していることも判明した（`provider_mode` は manual 指定に対し実際は auto、`targets` は `["claude"]` 指定に対し実際は `["claude","codex"]`）。deployment 側の整合は別 issue で扱う。

## 検証

```
shellcheck -S warning install.sh test/test-dotfiles-doctor.sh .shell-utils/dotfiles-doctor.sh   # ok
bash -n install.sh                                                                              # ok
bash test/test-dotfiles-doctor.sh                                                                # ok
bash test/test-claude-sandbox.sh                                                                 # ok
python3 -m unittest discover -s claude/hooks/tests -p 'test_*.py'                                 # 17 tests, OK
```

method 表示のテストは実装前に失敗することを確認してから実装した。`install.sh` はこの PR では変更していない。
