### PR TITLE
fix(headroom): align setup_headroom with the real deployment and drop the Docker preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,9 +131,10 @@ legacy-data policy.
 ## Headroom Proxy
 
 `install.sh` installs Headroom 0.36.5 with `uv` and maintains a user-scoped
-Claude proxy on port 8787. It uses Docker when available and a native scheduled
-task otherwise. The beta output shaper is enabled and Claude Code is routed
-through the proxy from new shell sessions.
+proxy on port 8787. It uses Docker when available and a native scheduled task
+otherwise. Target selection is left to auto detection, so every supported tool
+that is installed gets configured. The beta output shaper is enabled, and new
+shell sessions route Claude Code and Codex through the proxy.
 
 `dotfiles-doctor.sh` prints the reported measurement method next to the
 reduction. `ESTIMATED` compares shaped output against a synthetic baseline

--- a/README.md
+++ b/README.md
@@ -131,8 +131,9 @@ legacy-data policy.
 ## Headroom Proxy
 
 `install.sh` installs Headroom 0.36.5 with `uv` and maintains a user-scoped
-proxy on port 8787. It uses Docker when available and a native scheduled task
-otherwise. Target selection is left to auto detection, so every supported tool
+proxy on port 8787. The proxy runs as a supervised native process, so launchd
+starts it at login and restarts it if it dies; no container runtime is
+involved. Target selection is left to auto detection, so every supported tool
 that is installed gets configured. The beta output shaper is enabled, and new
 shell sessions route Claude Code and Codex through the proxy.
 
@@ -164,9 +165,11 @@ connections, Claude Code version drift, and tool-output compaction):
 ~/.shell-utils/dotfiles-doctor.sh --harness-only
 ```
 
-If Docker is unavailable, rerunning `install.sh` migrates an existing Docker
-deployment to Headroom's native scheduled recovery instead of leaving a stale
-container deployment behind.
+Rerunning `install.sh` migrates an existing Docker deployment to the
+supervised native process instead of leaving a stale container behind. The
+Docker preset is not used: it needs a running Docker daemon, tracks the
+`:latest` image rather than the pinned version, and cannot restart itself from
+inside the container.
 
 ```bash
 ./install.sh --headroom-only

--- a/install.sh
+++ b/install.sh
@@ -359,6 +359,8 @@ setup_cli_tools() {
 # ========================================
 # Recreates the user-scoped deployment when missing or when the persisted
 # output-shaper settings drift. Prefer Docker and fall back to a native task.
+# Target selection is left to auto detection, so the deployment covers every
+# installed tool and the target list is not treated as drift.
 
 setup_headroom() {
   if ! command -v headroom > /dev/null 2>&1; then
@@ -378,8 +380,7 @@ setup_headroom() {
 
   if [ -f "$manifest" ] \
     && jq -e --arg preset "$preset" --arg runtime "$runtime" \
-      '.provider_mode == "manual"
-       and .targets == ["claude"]
+      '.provider_mode == "auto"
        and .preset == $preset
        and .runtime_kind == $runtime
        and .base_env.HEADROOM_ROLLOUT_CHANNEL == "beta"
@@ -409,8 +410,7 @@ setup_headroom() {
     --preset "$preset" \
     --runtime "$runtime" \
     --scope user \
-    --providers manual \
-    --target claude \
+    --providers auto \
     --profile default \
     --port 8787 \
     --backend anthropic \

--- a/install.sh
+++ b/install.sh
@@ -358,7 +358,11 @@ setup_cli_tools() {
 # Headroom persistent Claude proxy
 # ========================================
 # Recreates the user-scoped deployment when missing or when the persisted
-# output-shaper settings drift. Prefer Docker and fall back to a native task.
+# output-shaper settings drift. Runs the proxy as a supervised native process
+# (launchd on macOS, systemd on Linux) so it starts at login and is restarted
+# when it dies. The Docker preset needs a running Docker daemon, tracks the
+# :latest image instead of the pinned version installed above, and cannot
+# restart itself from inside the container.
 # Target selection is left to auto detection, so the deployment covers every
 # installed tool and the target list is not treated as drift.
 
@@ -369,14 +373,8 @@ setup_headroom() {
   fi
 
   local manifest="$HOME/.headroom/deploy/default/manifest.json"
-  local preset runtime
-  if command -v docker > /dev/null 2>&1 && docker info > /dev/null 2>&1; then
-    preset=persistent-docker
-    runtime=docker
-  else
-    preset=persistent-task
-    runtime=python
-  fi
+  local preset=persistent-service
+  local runtime=python
 
   if [ -f "$manifest" ] \
     && jq -e --arg preset "$preset" --arg runtime "$runtime" \
@@ -386,19 +384,9 @@ setup_headroom() {
        and .base_env.HEADROOM_ROLLOUT_CHANNEL == "beta"
        and .base_env.HEADROOM_OUTPUT_SHAPER == "1"' \
       "$manifest" > /dev/null 2>&1; then
-    echo "  exists: Headroom persistent Claude deployment ($preset)"
+    echo "  exists: Headroom persistent proxy ($preset)"
     if ! headroom install status --profile default 2>/dev/null | grep -q '^Status:.*running'; then
-      if jq -e '.preset == "persistent-task"' "$manifest" > /dev/null 2>&1; then
-        if [ -x "$HOME/.headroom/deploy/default/ensure-headroom.sh" ]; then
-          echo "  recovering Headroom with scheduled-task watchdog"
-          "$HOME/.headroom/deploy/default/ensure-headroom.sh" ||
-            echo "  failed: Headroom scheduled-task recovery"
-        else
-          echo "  waiting for Headroom scheduled recovery"
-        fi
-      else
-        headroom install start --profile default || echo "  failed: start Headroom deployment"
-      fi
+      headroom install start --profile default || echo "  failed: start Headroom deployment"
     fi
     return 0
   fi


### PR DESCRIPTION
Closes part of #51 (PR A)

`setup_headroom` と実際の deployment が別物になっていた問題を、実態に合わせて解消する。調査の途中で実態そのものを変える判断をしたため、2つのコミットに分かれている。

## 1. auto 検出に合わせる (c8118b6)

`--providers manual --target claude` を要求していたが、実際の deployment は `headroom deploy`（default が `--providers auto`）で作られていた。auto 検出は Claude Code と Codex の両方を見つけるため、drift 検知は次を比較していた。

| 条件 | 変更前 | 実態 |
|---|---|---|
| `provider_mode` | `manual` | `auto` |
| `targets` | `["claude"]` | `["claude","codex"]` |

一致しないので、`install.sh` を実行するたびに deployment を作り直そうとしていた。

- `--providers auto` にし、`--target claude` の明示をやめる
- drift 検知から `targets` の比較を外す。auto 検出の結果は環境ごとに正当に異なる（Codex がないホストでは短いリストになる）ため drift として扱わない

`base_env` の2条件（`HEADROOM_ROLLOUT_CHANNEL == "beta"`、`HEADROOM_OUTPUT_SHAPER == "1"`）は残した。`--env` の値は `manifest.json` の `base_env` に永続化され、プロセスにも届くことを検証済み。一致しなかったのは deployment が `deploy` 経由で作られていたからで、`deploy` には `--env` オプション自体がない。

## 2. Docker preset をやめる (b924ed4)

Docker daemon が応答すれば `persistent-docker` を選ぶ実装だったが、このマシンの Docker Desktop は `AutoStart = False` である。再起動後に daemon が上がらないので、container の `restart=unless-stopped` は働く相手がいない。結果として proxy は手で deploy するまで落ちたままで、`headroom deploy` に `--env` がないため手動 deploy のたびに beta と shaper が失われていた。

`persistent-service` + `runtime=python` に変更する。

- `planner.py:157` → `SupervisorKind.SERVICE`
- `supervisors.py:200` → macOS では `~/Library/LaunchAgents/com.headroom.default.plist` を `RunAtLoad=true` + `KeepAlive=true` で生成
- `supervisors.py:90` → `base_env` を runner script の `export` として書き出してから exec するので、shaper 設定は supervisor 経由でも生き残る
- `runtime.py:125` → 実体は `sys.executable -m headroom.cli proxy`。container を使わない

autostart とは別に Docker preset が劣る点が2つある。`ghcr.io/headroomlabs-ai/headroom:latest` を追うので install.sh が固定した 0.36.5 から外れる。また `runtime.py:421` のコメントにある通り、container 内には docker socket がないため自己再起動ができない。

`persistent-task` の recovery 分岐（`ensure-headroom.sh` watchdog）も削除した。drift 検知が preset `persistent-service` を要求するため、task deployment で recovery 経路へ到達することはあり得ず、`headroom install start` で足りる。

## 検証

移行を実行した後の実環境:

```
$ headroom install status --profile default
Preset:     persistent-service
Runtime:    python
Supervisor: service
Status:     running
Healthy:    yes

$ curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:8787/readyz
200

$ ps eww <proxy pid> | grep HEADROOM_
HEADROOM_ROLLOUT_CHANNEL=beta
HEADROOM_OUTPUT_SHAPER=1
HEADROOM_DEPLOYMENT_PRESET=persistent-service
```

LaunchAgent は `RunAtLoad` / `KeepAlive` 付きで生成され、runner script は `export HEADROOM_ROLLOUT_CHANNEL=beta` と `export HEADROOM_OUTPUT_SHAPER=1` を含む。

drift 条件を実 manifest に対して評価:

```
# 変更前 (manual / ["claude"] / docker)
jq -e '...'  → false (exit 1)

# 変更後 (auto / persistent-service / python)
jq -e '...'  → true  (exit 0)
```

```
shellcheck -S warning install.sh   # ok
bash -n install.sh                 # ok
bash test/test-dotfiles-doctor.sh   # ok
bash test/test-claude-sandbox.sh    # ok
```

`test/test-install.sh` はホストでは実行していない（`$HOME` へ書き込む設計で、CI の Ubuntu container 内で走らせるもの）。CI は `install.sh --symlinks-only` しか実行しないため、`setup_headroom` の変更は CI の対象外である。

## 含めなかったもの

#51 に書いていた「`headroom install apply` の失敗を握り潰さない」は外した。`|| echo "  failed: ..."` は install.sh 全体で10箇所使われている一貫したパターンで、`set -e` も使っていない。「個別のインストールが失敗しても続行して failed 行を出す」がこのスクリプトの設計方針であり、1箇所だけ変えるのは別の議論になる。deployment が起動していない場合は doctor が `headroom install status` の running / healthy で検知するため、検知経路は既にある。

残りは #51 の PR B（proxy 停止の検知と切り分け）と PR C（doctor で shaper の実状態を見る）で扱う。
