### PR TITLE
feat(headroom): report a stopped proxy at shell startup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
         run: shellcheck -S warning install.sh test/test-install.sh test/test-dotfiles-doctor.sh test/test-claude-sandbox.sh claude/hooks/validate-bash.sh .shell-utils/*.sh .shell-utils/claude-sandbox
       - name: Test dotfiles doctor
         run: bash test/test-dotfiles-doctor.sh
+      - name: Test headroom proxy check
+        run: zsh test/test-headroom-proxy-check.zsh
       - name: Test Claude sandbox canary
         run: bash test/test-claude-sandbox.sh
       - name: Test tool-output compaction

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
         run: shellcheck -S warning install.sh test/test-install.sh test/test-dotfiles-doctor.sh test/test-claude-sandbox.sh claude/hooks/validate-bash.sh .shell-utils/*.sh .shell-utils/claude-sandbox
       - name: Test dotfiles doctor
         run: bash test/test-dotfiles-doctor.sh
+      - name: Install zsh
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq zsh
       - name: Test headroom proxy check
         run: zsh test/test-headroom-proxy-check.zsh
       - name: Test Claude sandbox canary

--- a/.shell-utils/headroom-proxy-check.zsh
+++ b/.shell-utils/headroom-proxy-check.zsh
@@ -1,0 +1,29 @@
+# Warn when the Headroom proxy is not answering.
+#
+# ANTHROPIC_BASE_URL and OPENAI_BASE_URL point at the proxy, so Claude Code and
+# Codex both fail while it is stopped, with no hint about why. The proxy is a
+# launchd job that starts at login, so this only fires when something actually
+# went wrong.
+#
+# The port is probed directly rather than through the headroom CLI, which would
+# add a Python start-up to every new shell.
+
+# Resolved at source time: inside a function %N is the function name, not a path.
+_HEADROOM_PROXY_CHECK_ROOT="${${(%):-%N}:A:h:h}"
+
+_headroom_proxy_reachable() {
+  local port="$1" descriptor
+  # Without the module the state is unknowable; stay quiet rather than nag.
+  zmodload zsh/net/tcp 2> /dev/null || return 0
+  ztcp 127.0.0.1 "$port" 2> /dev/null || return 1
+  descriptor="$REPLY"
+  ztcp -c "$descriptor" 2> /dev/null
+  return 0
+}
+
+headroom_proxy_check() {
+  local port="${HEADROOM_PORT:-8787}"
+  _headroom_proxy_reachable "$port" && return 0
+  print -u2 "headroom proxy is not answering on port $port; Claude Code and Codex are routed through it"
+  print -u2 "  start it with: bash $_HEADROOM_PROXY_CHECK_ROOT/install.sh --headroom-only"
+}

--- a/.zshrc
+++ b/.zshrc
@@ -338,3 +338,8 @@ export HEADROOM_OUTPUT_SHAPER="1"
 export ANTHROPIC_BASE_URL="http://127.0.0.1:8787"
 export ENABLE_TOOL_SEARCH="true"
 # <<< headroom persistent env <<<
+
+# Tell me when the proxy configured above is down, instead of letting Claude Code
+# and Codex fail against a dead ANTHROPIC_BASE_URL.
+source ~/.shell-utils/headroom-proxy-check.zsh
+headroom_proxy_check

--- a/test/test-headroom-proxy-check.zsh
+++ b/test/test-headroom-proxy-check.zsh
@@ -1,0 +1,48 @@
+#!/usr/bin/env zsh
+set -euo pipefail
+
+TEST_DIR="${${(%):-%N}:A:h}"
+REPO_DIR="${TEST_DIR:h}"
+UTIL="$REPO_DIR/.shell-utils/headroom-proxy-check.zsh"
+
+TEST_OUTPUT_DIR=$(mktemp -d)
+trap 'rm -rf "$TEST_OUTPUT_DIR"' EXIT
+
+fail() {
+  print -u2 "FAIL: $*"
+  exit 1
+}
+
+assert_contains() {
+  local expected="$1" file="$2"
+  grep -Fq -- "$expected" "$file" || fail "missing output: $expected"
+}
+
+source "$UTIL"
+
+# A reachable proxy stays silent; every new shell would otherwise be noisy.
+_headroom_proxy_reachable() { return 0 }
+reachable="$TEST_OUTPUT_DIR/reachable"
+headroom_proxy_check > "$reachable" 2>&1
+[[ ! -s "$reachable" ]] || fail "reachable proxy produced output: $(<"$reachable")"
+
+# An unreachable proxy names the port and the command that brings it back.
+_headroom_proxy_reachable() { return 1 }
+unreachable="$TEST_OUTPUT_DIR/unreachable"
+HEADROOM_PORT=8787
+headroom_proxy_check > "$unreachable" 2>&1
+assert_contains "8787" "$unreachable"
+assert_contains "install.sh --headroom-only" "$unreachable"
+
+# The warning goes to stderr so it cannot leak into captured stdout.
+stdout_only="$TEST_OUTPUT_DIR/stdout-only"
+headroom_proxy_check 2> /dev/null > "$stdout_only"
+[[ ! -s "$stdout_only" ]] || fail "warning was written to stdout"
+
+# The real probe reports a port with no listener as unreachable.
+source "$UTIL"
+if _headroom_proxy_reachable 1; then
+  fail "port 1 reported as reachable"
+fi
+
+print "headroom proxy check tests: ok"


### PR DESCRIPTION
Closes part of #51 (PR B)

## 問題

`.zshrc` は `ANTHROPIC_BASE_URL` と `OPENAI_BASE_URL` を `127.0.0.1:8787` に向けている。proxy が落ちていると Claude Code と Codex の両方が接続先を失うが、それに気づく手段が `headroom install status` を手で叩くか doctor を回すかしかなかった。

PR #52 で proxy は launchd の job になり、ログイン時に起動して落ちれば `KeepAlive` で再起動する。つまり port が死んでいる状態は「何か本当に壊れている」ことを意味するので、出す価値がある。

## 変更

`.shell-utils/headroom-proxy-check.zsh` を追加し、`.zshrc` から source して呼ぶ。

- port へ直接繋いで判定する。`headroom` CLI を起動すると Python の起動コストが全てのシェルに乗るため使わない
- 繋がるときは何も出さない
- 繋がらないときだけ、port と復旧コマンドを stderr に2行出す

```
headroom proxy is not answering on port 8787; Claude Code and Codex are routed through it
  start it with: bash /Users/kz86n/ghq/github.com/WatanabeToshimitsu/dotfiles/install.sh --headroom-only
```

パスはハードコードせず、source 時に自分自身のパスから解決する（`~/.shell-utils` はリポジトリへの symlink なので `:A` で実体に解決できる）。関数内では `%N` が関数名になるため、解決は source 時に一度だけ行う。

`zsh/net/tcp` が読み込めない環境では状態が判定できないので、警告せず黙る。

### 配置

headroom 管理ブロック（`# >>> headroom persistent env >>>` … `# <<< ... <<<`）の**外側、後ろ**に置いた。manifest の `mutations` に `.zshrc` / `.bashrc` / `.profile` が `shell-block` として登録されており、`install apply` のたびにマーカー間が書き換わるため、内側に置くと消える。

### 分岐なし

#51 では「docker daemon が落ちている」か「daemon は動いているが headroom が落ちている」かを出し分ける想定だったが、PR #52 で Docker が構成から外れたため不要になった。port が死んでいる原因は「deployment が無い」「launchd の job が落ちている」「移行前の docker deployment が残っている」の3つだが、いずれも `install.sh --headroom-only` で直る。このリポジトリは1台のみで運用するため、移行前の deployment を想定した分岐も持たない。

深い診断（job が繰り返し失敗している等）はシェル起動時にやることではないので doctor 側、つまり PR C の担当とする。

## 検証

```
$ zsh test/test-headroom-proxy-check.zsh
headroom proxy check tests: ok
```

テストは4件。

1. 到達可能なら何も出さない
2. 到達不可なら port と `install.sh --headroom-only` を含む警告を出す
3. 警告は stdout ではなく stderr に出る
4. 実際の probe が、listener のいない port を到達不可と判定する

1〜3 は probe 関数を差し替えて socket を開かずに検証する。doctor のテストが `run_headroom_status` などを差し替えているのと同じ方式。

実機での確認:

```
# proxy 稼働中
$ zsh -c 'source .shell-utils/headroom-proxy-check.zsh; headroom_proxy_check'
(出力なし)

# 存在しない port
$ zsh -c 'HEADROOM_PORT=9999 source ...; HEADROOM_PORT=9999 headroom_proxy_check'
headroom proxy is not answering on port 9999; Claude Code and Codex are routed through it
  start it with: bash .../install.sh --headroom-only
```

コスト:

```
100 runs: 0.369s (3.69ms each)
```

その他:

```
shellcheck -S warning <CIと同じ対象>   # ok
bash test/test-dotfiles-doctor.sh       # ok
bash test/test-claude-sandbox.sh        # ok
```

新しい util は `.zsh` なので、CI の shellcheck 対象（`.shell-utils/*.sh`）には入らない。shellcheck は zsh を解析できないため意図通り。

CI に `zsh test/test-headroom-proxy-check.zsh` のステップを追加した。ubuntu-latest に zsh が入っているかはこの PR の CI で確認する。

## 含めなかったもの

#51 の「doctor の `next:` を実際に打つべきコマンドへ直す」は不要だった。確認したところ既に `install.sh --headroom-only` を案内している（`dotfiles-doctor.sh:95` と `:99`）。

`.zshrc` の作業ツリーには headroom が追加した `OPENAI_BASE_URL` の行が未コミットで残っているが、この PR では stage していない。
