### PR TITLE
feat(nvim): open the markdown live preview automatically

### DIFF
--- a/.config/nvim/lua/plugins/markdown.lua
+++ b/.config/nvim/lua/plugins/markdown.lua
@@ -1,9 +1,32 @@
 -- markdown-preview.nvim: the extra's default build (mkdp#util#install) is async
 -- and can no-op during headless bootstraps, leaving app/node_modules missing
 -- ("Cannot find module 'tslib'"). Build synchronously with npm instead.
+--
+-- The extra only lazy-loads the plugin on <leader>cp / :MarkdownPreview. Load it
+-- on the filetype instead so g:mkdp_auto_start opens the live browser preview as
+-- soon as a markdown buffer is entered (FileType fires before BufEnter, so the
+-- auto_start autocmd is registered in time for the buffer that triggered it).
 return {
   {
     "iamcco/markdown-preview.nvim",
     build = "cd app && npm install --no-fund --no-audit",
+    ft = { "markdown", "markdown.mdx" },
+    init = function()
+      vim.g.mkdp_auto_start = 1
+      vim.g.mkdp_auto_close = 1
+      vim.g.mkdp_theme = "dark"
+      vim.g.mkdp_echo_preview_url = 1
+
+      -- Open the preview without pulling focus away from the editor. Drop the
+      -- -g flag to have the browser come to the front instead.
+      if vim.fn.has("mac") == 1 then
+        vim.cmd([[
+          function! MkdpOpenInBackground(url) abort
+            call system('open -g ' . shellescape(a:url))
+          endfunction
+        ]])
+        vim.g.mkdp_browserfunc = "MkdpOpenInBackground"
+      end
+    end,
   },
 }


### PR DESCRIPTION
## What

Entering a markdown buffer in Neovim now opens the markdown-preview.nvim browser preview by itself — no `<leader>cp` needed.

## Why

The LazyVim `lang.markdown` extra lazy-loads markdown-preview.nvim only on `<leader>cp` / `:MarkdownPreview`, so seeing the rendered output always cost an extra keystroke.

## How

- Load the plugin on `ft = { "markdown", "markdown.mdx" }` and set `g:mkdp_auto_start`. `FileType` fires before `BufEnter`, so the auto_start autocmd is registered in time for the buffer that triggered the load.
- No manual `open_preview_page()` kick: that opens the preview twice, and the preview server rejects the second request (`TypeError: Cannot read properties of undefined (reading 'openBrowser')`).
- On macOS the browser is launched via `open -g`, so the preview appears without stealing focus from the editor. Drop the `-g` to reverse that.
- `g:mkdp_theme = "dark"` and `g:mkdp_echo_preview_url = 1` (the URL is useful when the window opens in the background).

## Verification

Ran headless Neovim against this branch's config with a stub `open` on `PATH`:

| case | result |
| --- | --- |
| enter a markdown buffer | exactly 1 browser launch, correct `http://localhost:<port>/page/1` URL |
| enter a non-markdown buffer | 0 launches |
| resolved lazy spec | `ft`, `cmd`, `keys = <leader>cp`, and the npm `build` all preserved |

Before the change the same probe recorded 0 launches, confirming the preview did not start on its own.

## Note

Every markdown buffer now spawns a preview, including ones opened via `$EDITOR` from other tools. `<leader>cp` still toggles it off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
