### PR TITLE
feat(doctor): report whether the proxy is actually shaping

### DIFF
--- a/.shell-utils/dotfiles-doctor.sh
+++ b/.shell-utils/dotfiles-doctor.sh
@@ -55,6 +55,25 @@ run_headroom_savings() {
   headroom output-savings
 }
 
+# The proxy reports its own feature flags, which is the only view that reflects
+# what the running process actually got. `headroom rollout status` resolves the
+# policy from the shell it runs in, so on the host it answers about the host.
+# /health exposes a fixed whitelist of flags and no credentials.
+run_headroom_runtime_flags() {
+  python3 -c '
+import json
+import sys
+import urllib.request
+
+url = "http://127.0.0.1:%s/health" % sys.argv[1]
+with urllib.request.urlopen(url, timeout=5) as response:
+    flags = json.load(response)["config"]["runtime_env"]
+for name in ("HEADROOM_OUTPUT_SHAPER", "HEADROOM_OUTPUT_HOLDOUT"):
+    value = flags.get(name)
+    print("%s=%s" % (name, "" if value is None else value))
+' "${HEADROOM_PORT:-8787}"
+}
+
 run_claude_mcp_list() {
   claude mcp list
 }
@@ -76,10 +95,34 @@ run_compactor_health() {
     health --days "$HARNESS_WINDOW_DAYS"
 }
 
+check_headroom_shaper() {
+  local flags shaper holdout
+  if ! flags=$(run_headroom_runtime_flags 2> /dev/null); then
+    warn "Headroom runtime flags could not be read; next: run curl -s http://127.0.0.1:${HEADROOM_PORT:-8787}/health"
+    return 0
+  fi
+
+  shaper=$(printf '%s\n' "$flags" | sed -n 's/^HEADROOM_OUTPUT_SHAPER=//p' | head -n 1)
+  holdout=$(printf '%s\n' "$flags" | sed -n 's/^HEADROOM_OUTPUT_HOLDOUT=//p' | head -n 1)
+
+  if [ "$shaper" = "1" ]; then
+    info "output shaper flag reached the proxy"
+  else
+    warn "proxy is answering but its output shaper is off; next: run install.sh --headroom-only"
+  fi
+
+  if [ -n "$holdout" ]; then
+    info "output holdout: $holdout"
+  else
+    info "no output holdout, so the reduction above stays ESTIMATED"
+  fi
+}
+
 check_headroom() {
   echo "== Headroom proxy =="
   local before=$WARNINGS
   local output status healthy savings method requests saved reduction
+  local reachable=0
 
   if ! has_command headroom; then
     warn "Headroom is not installed; next: rerun install.sh"
@@ -91,8 +134,10 @@ check_headroom() {
       healthy=$(printf '%s\n' "$output" | sed -n 's/^Healthy:[[:space:]]*//p' | head -n 1)
       if [[ "$status" == *running* && "$healthy" == yes* ]]; then
         info "deployment is running and proxy is reachable"
+        reachable=1
       elif [[ "$status" != *running* && "$healthy" == yes* ]]; then
         warn "Persistent Headroom deployment is stopped while a temporary proxy is reachable; next: close headroom wrap sessions, then run install.sh --headroom-only"
+        reachable=1
       elif [[ "$status" == *running* ]]; then
         warn "Headroom deployment is running but its proxy is unreachable; next: run headroom doctor"
       else
@@ -118,6 +163,10 @@ check_headroom() {
       fi
     else
       warn "Headroom output-savings check failed; next: run headroom output-savings"
+    fi
+
+    if [ "$reachable" -eq 1 ]; then
+      check_headroom_shaper
     fi
   fi
   section_ok "$before"

--- a/test/test-dotfiles-doctor.sh
+++ b/test/test-dotfiles-doctor.sh
@@ -66,6 +66,10 @@ run_compactor_health() {
     'hook last error: none'
 }
 
+run_headroom_runtime_flags() {
+  printf '%s\n' 'HEADROOM_OUTPUT_SHAPER=1' 'HEADROOM_OUTPUT_HOLDOUT='
+}
+
 healthy_output="$TEST_OUTPUT_DIR/healthy"
 WARNINGS=0
 check_agent_harness > "$healthy_output"
@@ -73,6 +77,8 @@ check_agent_harness > "$healthy_output"
 assert_contains "2 MCP server(s) connected" "$healthy_output"
 assert_contains "installed 2.1.241; latest stable 2.1.241" "$healthy_output"
 assert_contains "hook active; last invoked 2026-08-26T00:00:00Z" "$healthy_output"
+assert_contains "output shaper flag reached the proxy" "$healthy_output"
+assert_contains "no output holdout" "$healthy_output"
 
 run_headroom_savings() {
   printf '%s\n' \
@@ -104,6 +110,45 @@ assert_contains "output shaper: MEASURED; 1,950 shaped" "$measured_output"
 
 run_headroom_savings() {
   printf 'No shaped requests recorded yet.\n'
+}
+
+# A reachable proxy that is not shaping is the failure this check exists for.
+run_headroom_runtime_flags() {
+  printf '%s\n' 'HEADROOM_OUTPUT_SHAPER=' 'HEADROOM_OUTPUT_HOLDOUT='
+}
+
+shaper_off_output="$TEST_OUTPUT_DIR/shaper-off"
+WARNINGS=0
+check_headroom > "$shaper_off_output"
+[ "$WARNINGS" -eq 1 ] || fail "shaper off produced $WARNINGS warning(s), expected 1"
+assert_contains "output shaper is off" "$shaper_off_output"
+assert_contains "install.sh --headroom-only" "$shaper_off_output"
+
+# A configured holdout is what turns the reported savings into a measurement.
+run_headroom_runtime_flags() {
+  printf '%s\n' 'HEADROOM_OUTPUT_SHAPER=1' 'HEADROOM_OUTPUT_HOLDOUT=0.1'
+}
+
+holdout_output="$TEST_OUTPUT_DIR/holdout"
+WARNINGS=0
+check_headroom > "$holdout_output"
+[ "$WARNINGS" -eq 0 ] || fail "configured holdout produced $WARNINGS warning(s)"
+assert_contains "output holdout: 0.1" "$holdout_output"
+
+# An unreadable /health must warn rather than claim the shaper is off.
+run_headroom_runtime_flags() {
+  return 1
+}
+
+flags_failed_output="$TEST_OUTPUT_DIR/flags-failed"
+WARNINGS=0
+check_headroom > "$flags_failed_output"
+[ "$WARNINGS" -eq 1 ] || fail "unreadable flags produced $WARNINGS warning(s), expected 1"
+assert_contains "runtime flags could not be read" "$flags_failed_output"
+assert_not_contains "output shaper is off" "$flags_failed_output"
+
+run_headroom_runtime_flags() {
+  printf '%s\n' 'HEADROOM_OUTPUT_SHAPER=1' 'HEADROOM_OUTPUT_HOLDOUT='
 }
 
 run_headroom_status() {


### PR DESCRIPTION
Closes part of #51 (PR C)

## 問題

doctor は「proxy に到達できる」と報告しながら、output shaper が無効な状態を見逃していた。このマシンが実際にその状態だった。`install.sh` は `--env HEADROOM_OUTPUT_SHAPER=1` を渡していたが、deployment は `headroom deploy`（`--env` を持たない）で作られていたため、フラグはプロセスに届いていなかった。

つまり「常駐しているのに主要機能が効いていない」という状態を、既存の check では検知できなかった。

## なぜ `headroom rollout status` を使わないか

ホストで実行すると、そのシェルの環境で policy を解決してしまう。

```
# ホスト
$ headroom rollout status
Rollout channel: stable
  proxy_output_shaper: enabled=false decision=not_requested

# proxy の runtime 内（移行前、container だった頃）
$ docker exec headroom-default headroom rollout status
Rollout channel: beta
  proxy_output_shaper: enabled=true decision=legacy_alias
```

同じコマンドが逆の答えを返す。doctor がホスト側の値を読むと、実態と反対のことを報告する。

## 変更

proxy 自身の `/health` からフラグを読む。

```
$ curl -s http://127.0.0.1:8787/health | jq .config.runtime_env
{
  "HEADROOM_EFFORT_ROUTER": "0",
  "HEADROOM_INTERCEPT_READ_MIN_CHARS": null,
  "HEADROOM_MECHANICAL_EFFORT": null,
  "HEADROOM_OUTPUT_HOLDOUT": null,
  "HEADROOM_OUTPUT_SHAPER": "1",
  "HEADROOM_VERBOSITY_AUTOTUNE": null,
  "HEADROOM_VERBOSITY_LEVEL": null
}
```

`runtime_env` は feature flag 7個の固定の whitelist で、credential は含まれない。doctor が読むのはそのうち2つだけ。

- `HEADROOM_OUTPUT_SHAPER` が `1` なら info、そうでなければ warn（proxy は応答しているのに shaping していない）
- `HEADROOM_OUTPUT_HOLDOUT` を報告する。これが未設定であることが、PR #50 で追加した reduction 行が `ESTIMATED` になる理由そのものなので、並べて出す意味がある

取得は `jq` や `curl` ではなく python3 の urllib で行う。doctor は既に python3 を依存として持っている（compaction health で使用）が、jq と curl は使っていないため、依存を増やさない。

proxy が応答しないときはこの check を実行しない。到達不能という同じ原因で warning が2つ出るのを避けるため。

## 実行例

```
== Headroom proxy ==
  deployment is running and proxy is reachable
  output shaper: ESTIMATED; 2,675 shaped; 1,745,576 output tokens; 58.7%   (95% CI 5.1% … 112.3%)
  output shaper flag reached the proxy
  no output holdout, so the reduction above stays ESTIMATED
  ok
```

移行前は 1,950 shaped で止まっていたものが 2,675 まで伸びており、shaper が実際に動き出したことも確認できる。

## 検証

テストを4件追加した。既存の doctor テストと同じく、`run_headroom_runtime_flags` を差し替えて実際の HTTP を使わずに検証する。

1. 正常系（shaper on / holdout なし）で 0 warning、両方の info が出る
2. shaper off で 1 warning、`install.sh --headroom-only` を案内する
3. holdout が設定済みならその値を出し、warning は出さない
4. `/health` が読めないときは「flags could not be read」で warn し、`output shaper is off` とは言わない

4 は誤診の防止が目的。取得失敗を「shaper が無効」と報告してはいけない。

到達不能時に check が走らないことは、既存の unhealthy テスト（warning 数 5 のまま変化しない）でカバーされている。

```
bash test/test-dotfiles-doctor.sh                                   # ok
shellcheck -S warning .shell-utils/dotfiles-doctor.sh test/...       # ok
bash .shell-utils/dotfiles-doctor.sh --harness-only                  # 実機で上記の出力
```

## 限界

`/health` が返すのは proxy プロセスに届いた環境変数であり、rollout policy の解決結果（`decision=legacy_alias` のような）ではない。`/health` は rollout channel を公開していないため、HTTP 経由で取れる最良の信号がこれになる。実際に踏んだ障害は「env がプロセスに届いていない」だったので、検知したい対象は捉えている。

なお `HEADROOM_OUTPUT_SHAPER=1` は `decision=legacy_alias` 扱いの旧式指定で、将来廃止される可能性がある（#51 に記載済み）。

## 残り

#51 の後続として、shaper が有効になった今 `HEADROOM_OUTPUT_HOLDOUT` を入れて `Method: MEASURED` を得る作業が残る（PR #50 で見送った分）。上の実行例の通り 95% CI の上限が 112.3% で、依然として存廃判断には使えない。
