### PR TITLE
feat(headroom): reserve a 10% holdout so savings are measured

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,11 +137,13 @@ involved. Target selection is left to auto detection, so every supported tool
 that is installed gets configured. The beta output shaper is enabled, and new
 shell sessions route Claude Code and Codex through the proxy.
 
-`dotfiles-doctor.sh` prints the reported measurement method next to the
-reduction. `ESTIMATED` compares shaped output against a synthetic baseline
-and can report a confidence band wider than the reduction itself, so it is
-not a basis for deciding whether the proxy earns its place. `MEASURED`
-requires an unshaped control arm via `HEADROOM_OUTPUT_HOLDOUT`.
+A 10% holdout leaves one conversation in ten unshaped as a control arm, so
+`headroom output-savings` reports `MEASURED` instead of `ESTIMATED`. That costs
+the shaping on those conversations. Without it the reported reduction is
+compared against a synthetic baseline and comes back with a confidence band
+wider than the reduction itself, which is no basis for deciding whether the
+proxy earns its place. `dotfiles-doctor.sh` prints the reported method next to
+the reduction, and the holdout below it.
 
 Learn the preferred response length again after enough Claude history has
 accumulated:

--- a/install.sh
+++ b/install.sh
@@ -382,7 +382,8 @@ setup_headroom() {
        and .preset == $preset
        and .runtime_kind == $runtime
        and .base_env.HEADROOM_ROLLOUT_CHANNEL == "beta"
-       and .base_env.HEADROOM_OUTPUT_SHAPER == "1"' \
+       and .base_env.HEADROOM_OUTPUT_SHAPER == "1"
+       and .base_env.HEADROOM_OUTPUT_HOLDOUT == "0.1"' \
       "$manifest" > /dev/null 2>&1; then
     echo "  exists: Headroom persistent proxy ($preset)"
     if ! headroom install status --profile default 2>/dev/null | grep -q '^Status:.*running'; then
@@ -406,6 +407,7 @@ setup_headroom() {
     --no-telemetry \
     --env HEADROOM_ROLLOUT_CHANNEL=beta \
     --env HEADROOM_OUTPUT_SHAPER=1 \
+    --env HEADROOM_OUTPUT_HOLDOUT=0.1 \
     || echo "  failed: Headroom persistent Claude deployment"
 }
 


### PR DESCRIPTION
Closes #51 の後続項目

## 問題

output shaper は PR #52 の移行で実際に動き出したが、削減量は依然として推定値のままである。直近の doctor 実行:

```
output shaper: ESTIMATED; 2,675 shaped; 1,745,576 output tokens; 58.7%   (95% CI 5.1% … 112.3%)
no output holdout, so the reduction above stays ESTIMATED
```

信頼区間の幅が削減率そのものより広く、上限が 100% を超えている。これでは epic #33 が下したい「Headroom を残すか外すか」の判断ができない。

`headroom output-savings --help` の説明:

> * "measured" — from an A/B holdout (set HEADROOM_OUTPUT_HOLDOUT>0), the unbiased difference between unshaped and shaped arms.
> * "estimated" — synthetic control: shaped output vs. the per-stratum baseline learned by `headroom learn --verbosity`.

## 変更

`HEADROOM_OUTPUT_HOLDOUT=0.1` を deployment に追加する。会話の10分の1を shaping せず対照群として残し、`output-savings` を `MEASURED` にする。

drift 検知条件にも同じキーを加えた。これによって次の `install.sh --headroom-only` が再適用を行う。

```
$ jq -r '.base_env.HEADROOM_OUTPUT_HOLDOUT // "unset"' ~/.headroom/deploy/default/manifest.json
unset

$ # 変更後の drift 条件を実 manifest に対して評価
$ jq -e '... and .base_env.HEADROOM_OUTPUT_HOLDOUT == "0.1"' ...
exit=1   # 再適用が走る
```

この条件が機能することは既に確認済み。`--env` で渡した値は `manifest.json` の `base_env` に永続化され、プロセスにも届く（PR #52 の移行時に `ps eww` と `/health` の両方で確認した）。PR #50 で同じ変更を見送ったのは、当時の deployment が `headroom deploy` 由来で `--env` が反映されていなかったためで、前提が解消された。

## トレードオフ

10% の会話は shaping されないので、その分の output token 削減は失われる。判断できない状態を続けるコストの方が大きいと考えた。答えが出れば holdout は外せる。

## 適用後の確認手順

マージ後に:

```
bash install.sh --headroom-only
```

deployment が再適用され、proxy が一度落ちて上がる。その後:

```
~/.shell-utils/dotfiles-doctor.sh --harness-only
```

doctor の holdout 行が `output holdout: 0.1` になる（PR #55 で追加した行）。`Method` が `MEASURED` に変わるのは対照群のデータが溜まってからで、即時ではない。

数日後に実測値が出たら #33 にコメントで残し、それをもとに Headroom の存廃を決める。

## 検証

```
shellcheck -S warning install.sh          # ok
bash -n install.sh                        # ok
bash test/test-dotfiles-doctor.sh          # ok
zsh test/test-headroom-proxy-check.zsh     # ok
bash test/test-claude-sandbox.sh           # ok
```

`install.sh --headroom-only` はこのブランチでは実行していない。実行すると proxy が再作成され、稼働中の Claude Code と Codex のセッションが切れるため、マージ後に行う。

## コメントについて

`install.sh` には holdout の理由をコメントで書いていない。`--env HEADROOM_OUTPUT_HOLDOUT=0.1` の行はそれ自体で読めるため。推定と実測の違いという非自明な部分は README に置いた。#59 の方針に沿っている。

`setup_headroom` のヘッダには私が以前書いた6行のコメントが残っているが、この PR では触っていない。リファクタと機能変更を混ぜないため、#59 の後続で扱う。
