### PR TITLE
feat(claude): Knipを使うrepository-audit Skillを追加

### DIFF
--- a/claude/.gitignore
+++ b/claude/.gitignore
@@ -19,6 +19,7 @@ skills/*
 !skills/delivery-workflow/
 !skills/expand-tool-output/
 !skills/prepare-compaction/
+!skills/repository-audit/
 !skills/ticket/
 # Concrete IDs, board URLs, and option labels stay local: this repo is public
 skills/ticket/reference.md

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -21,6 +21,7 @@
 - リファクタリングと機能変更を同じ変更に混ぜない。
 - 無関係な作業ツリーの変更を保護し、ファイルを明示して stage する。
 - 権限に配送が含まれる場合は、検証後に論理単位で commit、push し、必要なら Draft PR まで進める。
+- JavaScript/TypeScript を含む範囲のリポジトリ検査やリファクタリングでは、`repository-audit` skill を使い、Knip の結果または実行できなかった理由を残す。
 
 詳細な進行手順とレビュー基準は、該当時に `delivery-workflow` と `code-review` skill を使う。
 

--- a/claude/skills/repository-audit/SKILL.md
+++ b/claude/skills/repository-audit/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: repository-audit
+description: Audit or refactor a repository for dead code, unused files, exports, and dependencies. Use when asked to inspect a repository, assess repository health, clean up, simplify, reduce, or refactor. When the requested scope includes a JavaScript or TypeScript package graph, include Knip. Do not use for feature work that does not involve inspection or refactoring.
+---
+
+# Repository Audit
+
+Match the requested authority. An inspection or audit is read-only unless the user also asks for changes.
+
+## JavaScript and TypeScript
+
+Treat Knip as required evidence when the requested inspection or refactoring scope includes a JavaScript or TypeScript package graph:
+
+1. Inspect the package manager, workspace layout, package scripts, local Knip dependency, and Knip configuration.
+2. Prefer the repository's existing script and locked local version.
+3. If Knip is not available locally, ask before downloading an explicit version for a temporary run. Do not modify a manifest or lockfile solely to make that temporary run available.
+4. Record the command and Knip version. Run it from the workspace where its entry points and package manifest are defined.
+5. Address configuration hints first. Read findings from their root cause: unused files, unresolved imports, unused exports, then dependencies.
+
+A Knip finding is evidence of an unreachable item, not permission to delete it. Check framework entry points, dynamic imports, generated files, scripts, public package exports, and other external consumers. Prefer teaching Knip about a real entry point over adding a broad ignore.
+
+For a refactoring change, capture a baseline before editing, change one coherent category at a time, rerun Knip, and run the repository's relevant tests and build. When authorized cleanup removes a dependency, update its manifest and lockfile together. Treat the work as incomplete until Knip has run or the final report explains why it could not run.
+
+## Other ecosystems
+
+Knip does not apply when the requested scope has no JavaScript or TypeScript package graph. Use the relevant ecosystem's native dead-code and dependency checks and state that Knip was not applicable.
+
+## Report
+
+Return findings with the command, tool version, relevant locations, and the reachability reason. Separate confirmed dead code from configuration gaps and items that need a human decision. Report changes only when they were authorized, along with post-change Knip and test results.

--- a/symlink-manifest.sh
+++ b/symlink-manifest.sh
@@ -42,6 +42,7 @@ MANIFEST_CLAUDE_FILES=(
   skills/delivery-workflow/SKILL.md
   skills/expand-tool-output/SKILL.md
   skills/prepare-compaction/SKILL.md
+  skills/repository-audit/SKILL.md
   skills/ticket/SKILL.md
   rules/golang/coding-style.md
   rules/golang/hooks.md


### PR DESCRIPTION
## 概要

JavaScriptまたはTypeScriptを含む範囲のリポジトリ検査とリファクタリングで、Knipを確認項目にする`repository-audit` Skillを追加します。

Closes #62

## 変更内容

- `repository-audit` Skillを追加
- `~/.claude/CLAUDE.md`からSkillを1行だけ参照
- `.gitignore`とsymlink manifestへSkillを追加

## Knipの扱い

- projectにあるscript、設定、lock済みversionを優先する
- Knipが未導入なら、一時downloadの前に許可を求める
- 一時実行のためにmanifestやlockfileを変更しない
- findingを削除指示として扱わず、entry point、dynamic import、generated file、public APIを確認する
- 検査だけの依頼ではfileを変更しない
- 混在言語repositoryでは、依頼範囲にJavaScriptまたはTypeScriptのpackage graphが含まれる場合だけKnipを必須にする

Knipのglobal install、dotfilesへの`package.json`追加、全projectへの設定配布、CIへの一律導入は行いません。

## 検証

- skill-creator `quick_validate.py`: `Skill is valid!`
- Docker内の`test/test-install.sh`: `All tests passed!`
  - Skillのsymlink作成とuninstall時の削除を確認
- `git diff --cached --check`: 問題なし

## 独立レビュー

実装に参加していない別エージェントへIssue、最終差分、検証結果だけを渡してレビューしました。

初回レビューでは、lockfile変更制限の適用範囲と、混在言語repositoryでのKnip適用範囲について2件の指摘があり、修正しました。再レビューではactionable findingなしでした。

Claude Fable 5による同条件のレビューも開始しましたが、`individual spend limit`により応答生成前に停止しました。このPRではFableレビューを完了できていません。
