### PR TITLE
test(claude): cover the deny paths of the PreToolUse hooks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: shellcheck
-        run: shellcheck -S warning install.sh test/test-install.sh test/test-dotfiles-doctor.sh test/test-claude-sandbox.sh claude/hooks/validate-bash.sh .shell-utils/*.sh .shell-utils/claude-sandbox
+        run: shellcheck -S warning install.sh test/test-install.sh test/test-dotfiles-doctor.sh test/test-claude-sandbox.sh test/test-claude-hooks.sh claude/hooks/*.sh .shell-utils/*.sh .shell-utils/claude-sandbox
       - name: Test dotfiles doctor
         run: bash test/test-dotfiles-doctor.sh
+      - name: Test Claude hooks
+        run: bash test/test-claude-hooks.sh
       - name: Install zsh
         run: sudo apt-get update -qq && sudo apt-get install -y -qq zsh
       - name: Test headroom proxy check

--- a/test/test-claude-hooks.sh
+++ b/test/test-claude-hooks.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOKS_DIR="$(cd "$TEST_DIR/../claude/hooks" && pwd)"
+
+FAILURES=0
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  FAILURES=$((FAILURES + 1))
+}
+
+# A hook that permits the call stays silent, so no output means allow.
+decision_for() {
+  local hook="$1" payload="$2" output
+  output=$(printf '%s' "$payload" | bash "$HOOKS_DIR/$hook" 2> /dev/null)
+  if [ -z "$output" ]; then
+    printf 'allow\n'
+  else
+    printf '%s' "$output" | jq -r '.hookSpecificOutput.permissionDecision // "unparsed"'
+  fi
+}
+
+expect_decision() {
+  local hook="$1" payload="$2" expected="$3" label="$4" actual
+  actual=$(decision_for "$hook" "$payload")
+  [ "$actual" = "$expected" ] || fail "$hook: $label expected $expected, got $actual"
+}
+
+expect_exit() {
+  local hook="$1" payload="$2" expected="$3" label="$4" actual
+  printf '%s' "$payload" | bash "$HOOKS_DIR/$hook" > /dev/null 2>&1
+  actual=$?
+  [ "$actual" -eq "$expected" ] || fail "$hook: $label expected exit $expected, got $actual"
+}
+
+expect_nonzero_exit() {
+  local hook="$1" payload="$2" label="$3" actual
+  printf '%s' "$payload" | bash "$HOOKS_DIR/$hook" > /dev/null 2>&1
+  actual=$?
+  [ "$actual" -ne 0 ] || fail "$hook: $label expected a non-zero exit, got 0"
+}
+
+bash_payload() {
+  jq -n --arg command "$1" '{tool_name: "Bash", tool_input: {command: $command}}'
+}
+
+agent_payload() {
+  jq -n --arg subagent_type "$1" --arg model "$2" \
+    '{tool_name: "Agent", tool_input: {subagent_type: $subagent_type, model: $model}}'
+}
+
+expect_decision validate-bash.sh "$(bash_payload 'git add -A')" deny "the -A flag"
+expect_decision validate-bash.sh "$(bash_payload 'git add --all')" deny "the --all flag"
+expect_decision validate-bash.sh "$(bash_payload 'git add .')" deny "a bare dot"
+expect_decision validate-bash.sh "$(bash_payload 'git add . ; git commit -m x')" deny "a dot before a separator"
+expect_decision validate-bash.sh "$(bash_payload 'git add README.md')" allow "a named path"
+expect_decision validate-bash.sh "$(bash_payload 'git add ./src/main.ts')" allow "a relative path"
+expect_decision validate-bash.sh "$(bash_payload 'git commit -m x')" allow "an unrelated command"
+expect_decision validate-bash.sh '{"tool_name":"Read","tool_input":{}}' allow "a non-Bash tool"
+
+# Malformed input leaves the call permitted. This hook guards a personal
+# convention rather than a security boundary, so it fails open on purpose.
+expect_decision validate-bash.sh 'not json' allow "malformed input"
+expect_exit validate-bash.sh 'not json' 0 "malformed input"
+
+expect_decision require-subagent-model.sh "$(agent_payload general-purpose sonnet)" allow "an explicit model"
+expect_decision require-subagent-model.sh "$(agent_payload general-purpose inherit)" deny "an inherited model"
+expect_decision require-subagent-model.sh "$(agent_payload general-purpose '')" deny "a missing model"
+expect_decision require-subagent-model.sh "$(agent_payload sonnet-worker '')" allow "a pinned subagent type"
+expect_decision require-subagent-model.sh "$(agent_payload fable-deep '')" allow "a pinned subagent type"
+expect_decision require-subagent-model.sh '{"tool_name":"Read","tool_input":{}}' allow "a non-Agent tool"
+
+# This hook runs under `set -e`, so malformed input aborts instead of denying.
+# The exact status comes from jq and is not asserted.
+expect_decision require-subagent-model.sh 'not json' allow "malformed input"
+expect_nonzero_exit require-subagent-model.sh 'not json' "malformed input"
+
+if [ "$FAILURES" -ne 0 ]; then
+  printf 'claude hook tests: %d failure(s)\n' "$FAILURES" >&2
+  exit 1
+fi
+
+printf 'claude hook tests: ok\n'


### PR DESCRIPTION
Parent: #37

`hookをshellcheck対象へ加える` と `実害の大きいhookに、代表的な正常系・拒否系・不正JSONのfixtureを加える` の2項目。どちらも「hook が CI で守られていない」という同じ問題なので1つの PR にした。

## 問題

`settings.json` の PreToolUse に登録されている hook は2つあり、どちらもツール呼び出しを拒否できる。

| hook | matcher | 役割 |
|---|---|---|
| `validate-bash.sh` | `Bash` | `git add -A` 系を拒否する |
| `require-subagent-model.sh` | `Agent` | model 未指定・`inherit` の subagent を拒否する |

このうち shellcheck の対象は `validate-bash.sh` だけで、挙動のテストはどちらにも無かった。正規表現が壊れても条件が1つ落ちても、hook が黙って何も守らなくなるまで気づけない。

## 変更

`test/test-claude-hooks.sh` を追加し、CI に組み込む。shellcheck の対象は `claude/hooks/validate-bash.sh` の名指しをやめて `claude/hooks/*.sh` にした。4つとも現状で shellcheck を通るため、修正は発生していない。

hook は許可時に何も出力しないので、出力が空であることを「allow」として扱う。

### validate-bash.sh

| 入力 | 期待 |
|---|---|
| `git add -A` | deny |
| `git add --all` | deny |
| `git add .` | deny |
| `git add . ; git commit -m x` | deny |
| `git add README.md` | allow |
| `git add ./src/main.ts` | allow |
| `git commit -m x` | allow |
| `tool_name` が `Bash` 以外 | allow |
| 不正な JSON | allow、exit 0 |

### require-subagent-model.sh

| 入力 | 期待 |
|---|---|
| model が `sonnet` | allow |
| model が `inherit` | deny |
| model が空 | deny |
| `subagent_type` が `sonnet-worker` | allow |
| `subagent_type` が `fable-deep` | allow |
| `tool_name` が `Agent` 以外 | allow |
| 不正な JSON | allow、非ゼロ終了 |

## 不正 JSON の扱いが2つの hook で違う

- `validate-bash.sh` は `set -e` を使っていないため、`jq` が失敗しても `tool_name` が空になって exit 0 で通る（fail open）
- `require-subagent-model.sh` は `set -euo pipefail` のため `jq` の失敗でそのまま非ゼロ終了する

この差は現状のまま assert した。挙動の変更は #37 のスコープ外であり、別に判断すべきものとして残す。`validate-bash.sh` が fail open であること自体は、この hook が security boundary ではなく個人の運用方針を守るものなので許容範囲だと考えている。

非ゼロ終了のテストは終了コードの値を assert していない。`jq` のパースエラーの終了コードに依存させないため、非ゼロであることだけを見る。

## 検証

```
$ bash test/test-claude-hooks.sh
claude hook tests: ok

$ shellcheck -S warning test/test-claude-hooks.sh claude/hooks/*.sh
(no output)
```

テストが実際に退行を捉えることを mutation で確認した。hook のコピーを作り、2箇所を壊して実行した。

- `validate-bash.sh` の正規表現から `--all` の選択肢を削除
- `require-subagent-model.sh` から `"$model" != "inherit"` の条件を削除

```
FAIL: validate-bash.sh: the --all flag expected deny, got allow
FAIL: require-subagent-model.sh: an inherited model expected deny, got allow
claude hook tests: 2 failure(s)
```

壊した2箇所だけが失敗し、他の assertion は通っている。検証はコピーに対して行い、リポジトリの hook は変更していない。

## 含めなかったもの

- `post-ts-lint.sh` と `notification.sh` は拒否を行わないため fixture の対象にしていない。shellcheck の対象には入れた
- `compact-tool-output.py` は既に17件の unittest がある
- SessionStart の `herdr-agent-state.sh` は `~/.claude/hooks/` にある実ファイルでこのリポジトリの管理外

#37 の残りは status line の version 固定と macOS smoke test。別の PR で扱う。
