### PR TITLE
chore(claude): pin the status line to a released version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,11 @@ jobs:
               with open(path) as f:
                   json.load(f)
               print("OK", path)
+
+          command = json.load(open("claude/settings.json"))["statusLine"]["command"]
+          if "@latest" in command:
+              raise SystemExit("statusLine must pin a version, got: %s" % command)
+          print("OK statusLine is pinned:", command)
           PY
       - name: Validate JSONC (VS Code)
         run: |

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -280,7 +280,7 @@
   },
   "statusLine": {
     "type": "command",
-    "command": "npx -y @owloops/claude-powerline@latest"
+    "command": "npx -y @owloops/claude-powerline@1.30.1"
   },
   "enabledPlugins": {
     "co-mlops-context@hdl-agent-plugins": true,


### PR DESCRIPTION
Parent: #37

`status lineの@latestを通常のversion指定へ変える` の項目。

## 問題

`claude/settings.json` の statusLine が浮動タグを指していた。

```json
"statusLine": {
  "type": "command",
  "command": "npx -y @owloops/claude-powerline@latest"
}
```

セッションごとに違うビルドを取り得るのに、リポジトリのどこにも差分が出ない。壊れたときに「いつ何が変わったのか」を辿る手がかりがない。

## 変更

現在のリリースである `1.30.1` に固定した。以降のアップグレードは通常のコミットとして差分に現れる。

あわせて CI に検査を追加した。既存の JSON 検証は構文を見るだけで、浮動タグへの差し戻しは通ってしまうため。

```python
command = json.load(open("claude/settings.json"))["statusLine"]["command"]
if "@latest" in command:
    raise SystemExit("statusLine must pin a version, got: %s" % command)
```

## 検証

固定した版が実際に動くことを確認した。

```
$ printf '{}' | npx -y @owloops/claude-powerline@1.30.1
 / ✱ Claude § 0 tokens
 ☉ $14.17 28% ▫▫▫▫▫▫▫▫▫▫ 0%
 ⧖ active
exit=0
```

検査の動作:

```
current: npx -y @owloops/claude-powerline@1.30.1
guard passes: True
guard would catch @latest: True
```

## 更新をどう拾うか

`renovate.json` は `{"extends": ["config:base"]}` のみで、JSON 内に文字列として埋まった npx のバージョンは検出対象外。固定したままにすると更新に気づけなくなる。

Renovate の customManager を正規表現で設定すれば拾えるが、#37 の対象外に「外部依存を更新するための独自基盤を増やさない」とあるため、この PR には含めていない。必要なら別途判断する。当面は手動更新で、その差分がレビュー可能になったこと自体が今回の目的である。

## stage について

`claude/settings.json` の作業ツリーには `model` と `effortLevel` の未コミット変更があるが、この PR では stage していない。statusLine の1行だけを index に入れている。
